### PR TITLE
Changing book title to "User Guide"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 
-CiviCRM User and Administrator Guide
-====================================
+CiviCRM User Guide
+==================
 
-This book is a guide for users and administrators of CiviCRM. It covers
-everything that normal users and administrators of CiviCRM need to know
+This book is a guide for users of CiviCRM and covers
+everything they need to know
 to work with CiviCRM on a day to day basis. Our aim is to cover all
 functionality that is available via CiviCRM's user interface.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
-site_name: 'CiviCRM user guide'
-site_url: http://rtfd.civicrm.org
+site_name: 'CiviCRM User Guide'
+site_url: https://docs.civicrm.org/user/en/stable/
 repo_url: https://github.com/civicrm/civicrm-user-guide
-site_description: 'A guide for users and administrators of CiviCRM.'
+site_description: 'A guide for CiviCRM users.'
 site_author: 'The CiviCRM community'
 
 


### PR DESCRIPTION
Book title currently reads "User and Administrator Guide". With all this talk of a separate Admin Guide, I figured it'd be good to make it clearer that the User Guide is the User Guide. 