### PR TITLE
#167 Updates to the community pages

### DIFF
--- a/docs/the-civicrm-community/bug-reporting.md
+++ b/docs/the-civicrm-community/bug-reporting.md
@@ -3,8 +3,7 @@
 As with all software, there may be times when CiviCRM
 doesn't work the way you expect it to.
 
-A good first step is to search the question & answer site
-([https://civicrm.stackexchange.com](https://civicrm.stackexchange.com/)) for similar
+A good first step is to search the question & answer site, [Stack Exchange](https://civicrm.stackexchange.com/), for similar
 problems and follow advice given there. If your problem hasn't been
 addressed, posting a question about it probably the right thing to do.
 
@@ -70,8 +69,7 @@ first.
 
 ## Recreating your problem on the demo site
 
-Recreating your bug on one of the demo sites
-([http://demo.civicrm.org](http://demo.civicrm.org) and select the demo
+Recreating your bug on one of the [demo sites](http://demo.civicrm.org) (select the demo
 site that matches your CiviCRM version) helps determine whether your
 problem is a result of a bug in the source code, or as a result of
 changes on your site. If you can show us that the code on the demo site
@@ -93,8 +91,7 @@ valuable, but be careful to not including sensitive information such as
 your database log-in.
 
 If the forum suggests you discovered a bug in CiviCRM, you can report it
-to the CiviCRM issue tracker
-[](http://issues.civicrm.org/jira/browse/CRM)[http://issues.civicrm.org/jira/browse/CRM](http://issues.civicrm.org/jira/browse/CRM).
+to the [CiviCRM issue tracker](http://issues.civicrm.org/jira/browse/CRM).
 
 ## Writing good bug reports
 
@@ -107,7 +104,7 @@ The best bug reports clearly state:
 -   What you did
 -   What you expected to happen
 -   What actually happened
--   Version of CiviCRM (must be included) 
+-   Version of CiviCRM (must be included)
 -   Which CMS platform and CMS version (must be included)
 -   Which browser and browser version (must be included)
 -   Version of PHP and MySQL

--- a/docs/the-civicrm-community/localising-civicrm.md
+++ b/docs/the-civicrm-community/localising-civicrm.md
@@ -28,14 +28,12 @@ Administer > Configure > Global Settings > Localization.
 ## Translations
 
 CiviCRM accommodates different languages, however the developers rely on
-the community to translate the text displayed. 
+the community to translate the text displayed.
 
 A number of languages have already been provided to a greater or lesser
 extent. Some have more than 90% of the text translated, others only 5%,
 and a number of languages have not been translated at all. Please check
-the online translation tool Transifex
-([http://www.transifex.net/projects/p/civicrm/](http://www.transifex.net/projects/p/civicrm/))
-to find out about your language of interest. Download and install it on
+the online translation tool [Transifex](http://www.transifex.net/projects/p/civicrm/) to find out about your language of interest. Download and install it on
 your CiviCRM installation to find out how well it will suit your needs.
 
 You may find that although the translation is correct, you would want to
@@ -51,19 +49,15 @@ translation efforts, though some are still under development.
     translate strings of text and keep an overview on its progress.
     Register there, look for your language, join the team or, if your
     language is not available, start translating.
-2.  A glossary
-    ([http://wiki.civicrm.org/confluence/display/CRM/Glossary+for+translations](http://wiki.civicrm.org/confluence/display/CRM/Glossary+for+translations))
+2.  A [glossary](http://wiki.civicrm.org/confluence/display/CRM/Glossary+for+translations)
     on CiviCRM's wiki will help you maintain consistency in your
     translations. It will also help you get some insight on how much
     work it will be to translate those strings of text that your users
     will most often see and that would therefore be the first to
     translate.
-3.  A tips and tricks wiki page
-    ([http://wiki.civicrm.org/confluence/display/CRMDOC/Localisation+community+building+howto](http://wiki.civicrm.org/confluence/display/CRMDOC/Localisation+community+building+howto))
-    explains how to set up your localization community.
-4.  A FAQ
-    ([http://wiki.civicrm.org/confluence/display/CRMDOC/Internationalisation+FAQ)](http://wiki.civicrm.org/confluence/display/CRMDOC/Internationalisation+FAQ)
-    on the CiviCRM wiki covers localisation.
+3.  A [tips and tricks](https://wiki.civicrm.org/confluence/display/CRMDOC/Localisation+community+building+howto) wiki page
+  explains how to set up your localization community.
+4.  A [FAQ page](https://wiki.civicrm.org/confluence/display/CRMDOC/Internationalisation+FAQ) on the CiviCRM wiki covers localisation.
 
 ## Getting Started
 
@@ -72,8 +66,7 @@ current translation? Here's how to do it (provided you have a bit of a
 technical background):
 
 1.  Go to transifex.net and create an account.
-2.  Look for your language on
-    [http://www.transifex.net/projects/p/civicrm/teams/](http://www.transifex.net/projects/p/civicrm/teams/)
+2.  Look for your language [here](http://www.transifex.net/projects/p/civicrm/teams/)
     and either join a team, or request the creation of a new one if
     needed.
 3.  Start translating!
@@ -82,7 +75,7 @@ technical background):
 
 The CiviCRM translation work flow is still a work-in-progress and until
 the process becomes more mature, you should probably refer to
-[http://wiki.civicrm.org/confluence/pages/viewpage.action?pageId=88408149](http://wiki.civicrm.org/confluence/pages/viewpage.action?pageId=88408149)
+[this page](https://wiki.civicrm.org/confluence/pages/viewpage.action?pageId=88408149)
 for the most current instructions.
 
 The work flow is heavily based on teamwork. Hopefully, there is already
@@ -100,12 +93,12 @@ make it easier to translate the part that you are interested in
 have been divided into *components*, which are CiviCRM plugins (e.g.,
 CiviCRM core, CiviMail, CiviContribute, etc.). A separate component
 should be available for each version of CiviCRM, starting with version
-3.2 (or 3.1, for language teams that have chosen to do so). 
+3.2 (or 3.1, for language teams that have chosen to do so).
 
 Each component itself contains a number of files, which themselves
 contain the strings to translate. The main component "CiviCRM" (the
 *core*) has close to 20 files (for *countries*, *provinces*, *menu*,
-etc.). 
+etc.).
 
 ## Tools and technical details
 
@@ -126,8 +119,7 @@ their work.
 
 The basic steps in online translation are:
 
-1.  Select a component on
-    [http://www.transifex.net/projects/p/civicrm/](http://www.transifex.net/projects/p/civicrm/).
+1.  Select a [component](http://www.transifex.net/projects/p/civicrm/).
     This will display the list of language teams for this component.
 2.  Click on the icon in the Options column next to the language you are
     interested in. This brings you to the list of files for this
@@ -142,13 +134,12 @@ The basic steps in online translation are:
 ### Offline translation
 
 Most translation is usually done with an offline translation tool. One
-of the most common is PoEdit (see
-[http://www.poedit.net](http://www.poedit.net/)), which is free software
+of the most common is [PoEdit](http://www.poedit.net/), which is free software
 and has a big community of users. The exact steps in translation using
 an offline tool depend on your tool of choice, but should follow the
 following steps:
 
-1.  Download the files from transifex.net you want to translate, 
+1.  Download the files from transifex.net you want to translate,
 2.  Load the files up in your translation tool and do your translations.
 3.  Send them back to the site when you are done.
 
@@ -163,21 +154,19 @@ and most strings will be marked as fuzzy. This could be a way to
 bootstrap a new translation, though.
 
 Building a translation memory based on words from the glossary could go
-a long way in insuring the consistency of your team's work. 
+a long way in insuring the consistency of your team's work.
 
-### Using version control (mostly for programmers) 
+### Using version control (mostly for programmers)
 
-Transifex keeps files in a version control system,
-[http://github.com/civicrm/l10n](http://github.com/civicrm/l10n). This
+Transifex keeps files in a [version control system](http://github.com/civicrm/l10n). This
 is useful to some users who find interacting with the Github site easier
-than downloading each file separately from Transifex. 
+than downloading each file separately from Transifex.
 
-### Consistency & consensus 
+### Consistency & consensus
 
 To insure a good consistency in the translation, every team is
 encouraged to build and use a glossary and employ peer review. You can
-find a glossary of common terms on
-[http://wiki.civicrm.org/confluence/display/CRM/Glossary+for+translations](http://wiki.civicrm.org/confluence/display/CRM/Glossary+for+translations).
+use this glossary of [common terms](http://wiki.civicrm.org/confluence/display/CRM/Glossary+for+translations).
 You definitely should translate these terms to your language, and make
 sure your team reaches a consensus on all terms.
 
@@ -196,10 +185,10 @@ things to keep in mind when organizing a translation sprint:
 
 -   Choose a good location, where people will be able to get online
     (enough computers for everybody, or desks to set up laptops and with
-    a decent Internet connection). 
+    a decent Internet connection).
 -   Provide instructions in advance on how to install an offline
     translation tool such as PoEdit, and have people ready to help
-    others install and use it. 
+    others install and use it.
 -   Create the glossary in advance. Present the glossary, discuss terms
     which do not have consensus, make sure everybody has access to a
     copy of the glossary, and print a sufficient amount of copies
@@ -218,4 +207,3 @@ things to keep in mind when organizing a translation sprint:
     demo CiviCRM installation.
 -   Discuss whether the team has reached its goal and how to improve
     further.
-

--- a/docs/the-civicrm-community/the-civicrm-community.md
+++ b/docs/the-civicrm-community/the-civicrm-community.md
@@ -18,54 +18,23 @@ access to the Internet you also have access to and can participate in
 the CiviCRM community regardless of where you live or work. English is
 the predominant language for discussion and contributions.
 
-The CiviCRM website itself ([http://civicrm.org](http://civicrm.org)) is
+The [CiviCRM website](https://civicrm.org) itself is
 a good starting point for exploring and participating in the community.
 In addition to general information about getting and using CiviCRM,
 you'll find blog posts from community members, announcements about
-upcoming events, and a Participate section
-([http://civicrm.org/participate](http://civicrm.org/participate)) that
+upcoming events, and a [Get Involved](https://civicrm.org/get-involved) section that
 lists and links to many of the resources described below.
 
-The CiviCRM Stack Exchange site ([http://civicrm.stackexchange.com](http://civicrm.stackexchange.com/))
-This is a fairly new site specfically designed for asking and answering questions about CiviCRM.  This is now the primary site for getting answers to questions on installing, upgrading, configuring, using and customizing CiviCRM.  
+The [CiviCRM Stack Exchange](http://civicrm.stackexchange.com/) site is specifically designed for asking and answering questions about CiviCRM.  This is now the primary site for getting answers to questions on installing, upgrading, configuring, using and customizing CiviCRM. It is a great place to find answers to the millions of questions that have already been asked about CiviCRM, and to ask ones that haven't been asked already.
 
-The CiviCRM Forums
-[(](http://forum.civicrm.org)[http://forum.civicrm.org](http://forum.civicrm.org))
-are a central location for CiviCRM discussion and support. The forums
-are divided into topical boards for:
+[Mattermost](https://chat.civicrm.org) offers live discussion in chat rooms and direct messages. It's a great place to go for any technical questions. Here, with a bit of luck, you'll often find an instant answer to your question or a pointer in the right direction.
 
--   Asking general questions
--   Getting technical support for installing, upgrading, configuring,
-    using, and customizing CiviCRM
--   Discussing and providing feedback on documentation
--   Feature requests and suggestions
--   Projects in internationalisation and localisation
--   Showcasing success stories and case studies
--   Conversations around modifying and extending CiviCRM
--   Coordination of testing
--   Obtaining or providing professional services
+The [CiviCRM Forums](http://forum.civicrm.org) are a location for language and locality based CiviCRM discussion and support.
 
-Registration for the forums is completely free and most of the boards
-are very active with frequent new posts and responses.
-
-Another great source of support and discussion is Internet Relay Chat
-(IRC). The #civicrm IRC channel is hosted by Freenode at
-[http://irc.civicrm.org/](http://irc.civicrm.org/) You can access the
-channel using an IRC client (a program that you run on your computer) or
-through the web interface at
-[http://webchat.freenode.net](http://webchat.freenode.net). Enter
-\#civicrm in the Channels field and a nickname of your choosing in the
-Nickname field. For more information on using IRC, check out the IRC
-section of the Drupal website
-([http://drupal.org/irc](http://drupal.org/irc)). Although the
-information is targeted to the Drupal community it can also be useful
-for CiviCRM users, especially because the Drupal IRC channels are also
-hosted on Freenode.
-
-You'll hopefully find that both the forums and the IRC channel are great
+You'll hopefully find that both Stack Exchange and Mattermost are great
 sources for help, support, and good ideas. That's all attributable to
 the good will and generous efforts of people like you! Everyone who
-visits the forums and the channel is encouraged to give back to the
+visits these sites is encouraged to give back to the
 community by responding to questions and requests for help and
 contributing their own ideas and feedback to the conversations. And
 simply asking your own questions is also a significant contribution to
@@ -73,7 +42,7 @@ the community. It's likely that someone else is having the same problems
 or wondering the same thing, and the responses you solicit help build
 the community's knowledge base.
 
-The CiviCRM blog ([http://civicrm.org/blog](http://civicrm.org/blog)) is
+The [CiviCRM blog](https://civicrm.org/blog) is
 another good source of information and discussion. Blog posts are
 written by both the CiviCRM core team and other community members and
 cover a wide range of topics, including general news and announcements,
@@ -102,27 +71,16 @@ and using CiviCRM.
 
 Many cities and regions hold CiviCRM meetups where people gather to
 learn about CiviCRM, share new ideas, developments, and use cases, and
-meet other folks involved with the community. You can find out more
-about meetups at [http://civicrm.org](http://civicrm.org). Some meetup
-and local user groups (or LUGs) also maintain discussion boards at
-[http://forum.civicrm.org/index.php/board,73.0.html](http://forum.civicrm.org/index.php/board,73.0.html).
-Contact the CiviCRM crew if you'd like a discussion board for your own
-group on the site.
+meet other folks involved with the community. CiviCRM also conducts user and developer training in cities around the world. Stay abreast of local events, whether meetups, trainings, or sprints [here](https://civicrm.org/local-events).
 
-CiviCRM held the first CiviCon conference in April 2010 in San
-Francisco. These have now settled into a pattern of two CiviCons per
-year - one in the USA in April/May and one in London in
-September/October. Stay tuned to CiviCRM.org for announcements of future
-CiviCons.
+There are also more formal gatherings for CiviCRM users and developers. CiviCRM held the first CiviCon conference in April 2010 in San
+Francisco. [CiviCon](https://civicrm.org/civicon) brings together prospective and current end-users, administrators and developers of CiviCRM for content-rich discussions, lectures and networking. The number of CiviCons hosted around the world each year is growing.
+
+CiviCamps are one-day, action packed meetups where you can learn about CiviCRM, connect with other users, ask questions, share tips, and more. See if there are any upcoming [CiviCamps](https://civicrm.org/civicamp) near you.
 
 CiviCRM core developers and community members also make appearances at
 other conferences, including DrupalCon, the NonProfit Technology
 Conference, Joomla! events, and Aspiration Tech events.
-
-CiviCRM also conducts user and developer training in cities around the
-globe. Check out [http://civicrm.org](http://civicrm.org) for info about
-upcoming trainings and contact CiviCRM if you'd like to host trainings
-in your own area.
 
 ## Open Source = Community Sourced
 
@@ -130,45 +88,35 @@ Here are some additional ways that you can participate in and contribute
 to the CiviCRM community.
 
 -   Contribute to CiviCRM documentation. This book was written by
-    community members; you can contribute to it by going to
-    [http://booki.flossmanuals.net/civicrm/_edit/](http://booki.flossmanuals.net/civicrm/_edit/),
-    registering, and clicking "Edit this page" on the page you want to
-    edit. You can also find and contribute to the CiviCRM documentation
-    wiki at
-    [http://wiki.civicrm.org/confluence/display/CRMDOC/CiviCRM+Documentation](http://wiki.civicrm.org/confluence/display/CRMDOC/CiviCRM+Documentation).
--   Share use cases and case studies that describe how your organization
-    uses CiviCRM and the solutions and processes you've developed around
-    the software. You can post your case studies to the CiviCRM.org
-    website by clicking **Add Case Study** from the Case Studies page:
-    [http://civicrm.org/what/casestudies](http://civicrm.org/what/casestudies)
--   You can also share your successes, experiences at Civi-related
-    events, interesting customizations, etc. on the CiviCRM.org blog:
-    [http://civicrm.org/blog](http://civicrm.org/blog) 
+    community members; you can contribute to it by
+    [following the instructions here](/the-civicrm-community/contributing-to-this-manual/).
+-   Contribute content to CiviCRM's website. You can share use cases and case studies that describe how your organization uses CiviCRM and the solutions and processes you've developed around
+    the software. See existing case studies  [here](https://civicrm.org/case-studies). You can also share your successes, experiences at Civi-related
+    events, interesting customizations, etc. on the
+    [CiviCRM blog](https://civicrm.org/blog). You can add content by [becoming a member](https://civicrm.org/become-a-member) or emailing [info@civicrm.org](mailto:info@civicrm.org) with a request to post.
 -   Share your training resources and materials with the rest of the
-    community through the wiki, the forums, or blog posts on the CiviCRM
-    blog or your own sites.
+    community through posts on the CiviCRM
+    blog or on your own sites.
+-   [Register your organization](https://civicrm.org/register-a-site) on CiviCRM's website. This will add your site to a publicly searchable directory and map of CiviCRM installations, supporting CiviCRM's marketing efforts.
 -   Contribute code you've written to extend CiviCRM, because it's
     likely that someone else out there needs the same functionality.
     Check out the recommended steps for developing and contributing to
-    the CiviCRM core codebase
-    at [http://wiki.civicrm.org/confluence/x/kADNAQ](http://wiki.civicrm.org/confluence/x/kADNAQ)[.](http://wiki.civicrm.org/confluence/display/CRM/Recommended+Steps+for+Developing+and+Contributing+to+CiviCRM+Core+Codebase.)
+    the CiviCRM how you can help contribute to the core codebase
+    in the [Developer Guide](https://docs.civicrm.org/dev/en/latest/).
     If you've developed a Drupal module, you should contribute it to
     Drupal.org; see
-    [http://drupal.org/node/7765](http://drupal.org/node/7765) for more
+    [their site](http://drupal.org/node/7765) for more
     information on contributing modules. Joomla! extensions can be
-    posted on [http://forge.joomla.org/](http://forge.joomla.org).
-    Finally, you can post your code on the CiviCRM Forums or wiki as
-    attachments.
+    posted [here](http://forge.joomla.org).
 -   Sponsor development of new features. If your organization needs
     certain features or functionality that doesn't yet exist for CiviCRM
     and can't develop those features in-house, you can sponsor their
     development by outside coders and developers. This can be a solo
     effort on the part of one organization or a coordinated effort
     sponsored by multiple organizations in need of the same set of
-    functionality. Refer to the wiki at
-    [http://wiki.civicrm.org/confluence/display/CRM/Developing+with+the+CiviCRM+team](http://wiki.civicrm.org/confluence/display/CRM/Developing+with+the+CiviCRM+team)
+    functionality. Find out more on
+    [CiviCRM's website](https://civicrm.org/work-with-the-core-team)
     or write to [info@civicrm.org](mailto:info@civicrm.org) for more
     information on sponsoring development.
 -   Report any bugs that you find in CiviCRM. See the *Bug Reporting*
     chapter of this book for more information.
-


### PR DESCRIPTION
I made a lot of updates to the CiviCRM community page (it was referencing the wiki and IRC as the primary ways to get in touch), including adding pieces about becoming a member and registering your site. I also updated a bunch of links on related pages. 