### PR TITLE
Update URL to "Schedule Reminders" chapter

### DIFF
--- a/docs/membership/renewals.md
+++ b/docs/membership/renewals.md
@@ -66,7 +66,7 @@ Schedule Reminders feature (**Administer > Communications > Schedule
 Reminders**). This is particularly helpful for rolling membership types,
 where memberships could be ending at any time during the year. Refer to
 the [Schedule
-Reminders](http://booki.flossmanuals.net/email/scheduled-reminders) chapter
+Reminders](https://docs.civicrm.org/user/en/stable/email/scheduled-reminders/) chapter
 in the *Email* section of this book for the steps involved in sending
 out a scheduled reminder once you have composed your message.
 


### PR DESCRIPTION
The reference to "the Schedule Reminders chapter in the Email section of this book" points at the old flossmanuals.net URL rather than the docs.civicrm.org URL.