### PR TITLE
Fix errors in api_parameters for Twilio

### DIFF
--- a/docs/sms-text-messaging/set-up.md
+++ b/docs/sms-text-messaging/set-up.md
@@ -196,8 +196,8 @@ Settings**> **SMS Providers**. Click **Add New Provider**.
 * Password: enter your "Auth Token" from the previous step
 * API type: leave as "http"
 * API URL: leave as "https://api.twilio.com/"
-* API Parameters: enter "From:" followed by your Twilio phone number from the
-previous step, in international format with no spaces. On a second line, enter "mo=1".
+* API Parameters: enter "From=" followed by your Twilio phone number from the
+previous step, in international format with no spaces.
 
 Click Save to create your provider.
 


### PR DESCRIPTION
The parameters should be separated by an equals sign, not a colon.

Also, the Clickatell extension looks for the `mo=1` parameter and if it finds it, it will include a callback parameter to clickatell. However, the twilio code has no such equivalent.