### PR TITLE
Remove weird double dash character. Replace with single dash

### DIFF
--- a/docs/email/reports-and-analysis.md
+++ b/docs/email/reports-and-analysis.md
@@ -28,7 +28,7 @@ opened the email *if you have chosen to track opens*.
 
 **Note:** In the world of email, there is no 100% reliable way of
 knowing when someone has opened an email. CiviCRM uses a trick that is
-common amongst mass mailers-it embeds a small image with a unique name
+common amongst mass mailers &mdash; it embeds a small image with a unique name
 in each email. When a client views the email and downloads the image,
 CiviCRM knows that they have read the email. Because this technique is
 common, to protect people's privacy, most email clients ask users to

--- a/docs/email/reports-and-analysis.md
+++ b/docs/email/reports-and-analysis.md
@@ -28,7 +28,7 @@ opened the email *if you have chosen to track opens*.
 
 **Note:** In the world of email, there is no 100% reliable way of
 knowing when someone has opened an email. CiviCRM uses a trick that is
-common amongst mass mailers—it embeds a small image with a unique name
+common amongst mass mailers-it embeds a small image with a unique name
 in each email. When a client views the email and downloads the image,
 CiviCRM knows that they have read the email. Because this technique is
 common, to protect people's privacy, most email clients ask users to

--- a/docs/email/set-up.md
+++ b/docs/email/set-up.md
@@ -149,8 +149,8 @@ Option B: Go to the profile settings. In the Advanced Settings section, select y
 
 For this to work, first make sure that you have put a tick on the desired **Enable Double Opt-in** options in **Administer > Administration Console > CiviMail Component Settings**.
 
-After people subscribe to mailing list groups-via the subscribe link or
-a profile-CiviCRM will automatically send them an email asking them to
+After people subscribe to mailing list groups &mdash; via the subscribe link or
+a profile &mdash; CiviCRM will automatically send them an email asking them to
 confirm their subscription. Until they click the confirmation link in
 the email, their contact information will appear in CiviCRM with their
 group subscription set to Pending. When they confirm, CiviCRM will

--- a/docs/email/set-up.md
+++ b/docs/email/set-up.md
@@ -149,8 +149,8 @@ Option B: Go to the profile settings. In the Advanced Settings section, select y
 
 For this to work, first make sure that you have put a tick on the desired **Enable Double Opt-in** options in **Administer > Administration Console > CiviMail Component Settings**.
 
-After people subscribe to mailing list groups—via the subscribe link or
-a profile—CiviCRM will automatically send them an email asking them to
+After people subscribe to mailing list groups-via the subscribe link or
+a profile-CiviCRM will automatically send them an email asking them to
 confirm their subscription. Until they click the confirmation link in
 the email, their contact information will appear in CiviCRM with their
 group subscription set to Pending. When they confirm, CiviCRM will

--- a/docs/events/creating-an-event.md
+++ b/docs/events/creating-an-event.md
@@ -42,7 +42,7 @@ Do you want users to see a list of participants, and how much
 information about the participants do you want to reveal? **Participant
 Listings** demonstrate support for an event and can help to generate
 interest within your constituent community. Note that the options you
-define in this section only *enable* participant listings — to display
+define in this section only *enable* participant listings - to display
 one, you will need to create a menu item or link to the listing
 somewhere on your website. Once you've created the event, the
 participant listing link is displayed on the event configuration page.

--- a/docs/events/creating-an-event.md
+++ b/docs/events/creating-an-event.md
@@ -42,7 +42,7 @@ Do you want users to see a list of participants, and how much
 information about the participants do you want to reveal? **Participant
 Listings** demonstrate support for an event and can help to generate
 interest within your constituent community. Note that the options you
-define in this section only *enable* participant listings - to display
+define in this section only *enable* participant listings &mdash; to display
 one, you will need to create a menu item or link to the listing
 somewhere on your website. Once you've created the event, the
 participant listing link is displayed on the event configuration page.

--- a/docs/initial-set-up/customizing-the-user-interface.md
+++ b/docs/initial-set-up/customizing-the-user-interface.md
@@ -4,7 +4,7 @@ CiviCRM is highly flexible and customizable. This chapter gives
 information on the many ways you can change the interface to suit your
 needs and make it easier for your users.
 
-How to customize your data itself-what you collect and track-is covered
+How to customize your data itself &mdash; what you collect and track &mdash; is covered
 in *Organising Your Data* and in the *What you need to know*and *Set-up*
 chapters in the sections on the different CiviCRM components (e.g.,
 learn about customizing event types in the *Events* section).
@@ -34,8 +34,8 @@ Postal Mail, SMS) in the contact edit/entry form can also be modified;
 go to **Administer > Communications > Preferred Communications
 Methods**.
 
-Modifying dropdown options that define data-such as Activity Type,
-Relationship, etc.-is outside the scope of this chapter; see *Organising
+Modifying dropdown options that define data &mdash; such as Activity Type,
+Relationship, etc. &mdash; is outside the scope of this chapter; see *Organising
 Your Data* and the sections on the different CiviCRM components.
 
 ## Changing display preferences

--- a/docs/initial-set-up/customizing-the-user-interface.md
+++ b/docs/initial-set-up/customizing-the-user-interface.md
@@ -4,7 +4,7 @@ CiviCRM is highly flexible and customizable. This chapter gives
 information on the many ways you can change the interface to suit your
 needs and make it easier for your users.
 
-How to customize your data itself—what you collect and track—is covered
+How to customize your data itself-what you collect and track-is covered
 in *Organising Your Data* and in the *What you need to know*and *Set-up*
 chapters in the sections on the different CiviCRM components (e.g.,
 learn about customizing event types in the *Events* section).
@@ -34,8 +34,8 @@ Postal Mail, SMS) in the contact edit/entry form can also be modified;
 go to **Administer > Communications > Preferred Communications
 Methods**.
 
-Modifying dropdown options that define data—such as Activity Type,
-Relationship, etc.—is outside the scope of this chapter; see *Organising
+Modifying dropdown options that define data-such as Activity Type,
+Relationship, etc.-is outside the scope of this chapter; see *Organising
 Your Data* and the sections on the different CiviCRM components.
 
 ## Changing display preferences

--- a/docs/organising-your-data/profiles.md
+++ b/docs/organising-your-data/profiles.md
@@ -127,7 +127,7 @@ Details about using Profiles to manage email lists are found in the
 Because Profiles can be used for so many different purposes, there are a
 lot of choices to make and settings to configure when setting them up.
 There are settings for the Profile as a whole and settings for each
-field you add—and the choice of what those fields are. Choices you make
+field you add-and the choice of what those fields are. Choices you make
 about one aspect will affect choices you can make about others. For
 example, some types of Profiles limit the kinds of fields you can
 include, and some combinations of fields are not allowed in any type of
@@ -149,7 +149,7 @@ Here are some guidelines on which fields can be added to a Profile:
     specific type. The Organization field menu, for example, contains
     only those fields that do not also apply to other Contact types.
 -   Except in Search Results Profiles, you can combine Contact fields
-    with fields from one—and only one—of the other record types:
+    with fields from one-and only one-of the other record types:
     Activity, Participants, Contributions, and Membership.
 -   If you try to combine fields with an unsupported combination of
     record types, you'll get an error when you try to save the field.
@@ -449,7 +449,7 @@ On the popup form, select Profile as the desired frontend element.
 ![image](../img/2013-09-04_15-15-35.png)
 
 Use the second select widget to specify the profile you would like to
-use. Finally, select the purpose of the form — create, edit or view —
+use. Finally, select the purpose of the form - create, edit or view -
 and click Insert Form.
 
 ![image](../img/2013-09-04_15-16-45.png)

--- a/docs/organising-your-data/profiles.md
+++ b/docs/organising-your-data/profiles.md
@@ -127,7 +127,7 @@ Details about using Profiles to manage email lists are found in the
 Because Profiles can be used for so many different purposes, there are a
 lot of choices to make and settings to configure when setting them up.
 There are settings for the Profile as a whole and settings for each
-field you add-and the choice of what those fields are. Choices you make
+field you add &mdash; and the choice of what those fields are. Choices you make
 about one aspect will affect choices you can make about others. For
 example, some types of Profiles limit the kinds of fields you can
 include, and some combinations of fields are not allowed in any type of
@@ -149,7 +149,7 @@ Here are some guidelines on which fields can be added to a Profile:
     specific type. The Organization field menu, for example, contains
     only those fields that do not also apply to other Contact types.
 -   Except in Search Results Profiles, you can combine Contact fields
-    with fields from one-and only one-of the other record types:
+    with fields from one and only one of the other record types:
     Activity, Participants, Contributions, and Membership.
 -   If you try to combine fields with an unsupported combination of
     record types, you'll get an error when you try to save the field.
@@ -449,7 +449,7 @@ On the popup form, select Profile as the desired frontend element.
 ![image](../img/2013-09-04_15-15-35.png)
 
 Use the second select widget to specify the profile you would like to
-use. Finally, select the purpose of the form - create, edit or view -
+use. Finally, select the purpose of the form &mdash; create, edit or view
 and click Insert Form.
 
 ![image](../img/2013-09-04_15-16-45.png)


### PR DESCRIPTION
I suspect this character has been copied from MS Word as it's giving weird non-printable output when viewing on a web page. Just replacing this with a single "normal" dash does the trick. This is a global find/replace.