### PR TITLE
CRM-21425: Make Inbound Emails Editable With Configuration Option

### DIFF
--- a/docs/email/set-up.md
+++ b/docs/email/set-up.md
@@ -254,3 +254,11 @@ accounts and set them up in CiviMail (see **Email System
 Configuration**, especially **Adding an incoming email account for
 handling bounces or auto filing to CiviMail**, in **Initial Set-Up** for
 more details).
+
+### Allowing users to edit inbound e-mails
+ 
+Activities created by CiviCRM as a result of email-to-activity processing 
+are not editable by users, as there is a restriction enforced on the Inbound 
+Email activity type. To allow users to be able to edit these activities, an
+administrator can enable the **Allow to Edit Inbound E-mails** option found on 
+**Administer > CiviMail > CiviMail Component Settings**

--- a/docs/email/set-up.md
+++ b/docs/email/set-up.md
@@ -260,5 +260,13 @@ more details).
 Activities created by CiviCRM as a result of email-to-activity processing 
 are not editable by users, as there is a restriction enforced on the Inbound 
 Email activity type. To allow users to be able to edit these activities, an
-administrator can enable the **Allow to Edit Inbound E-mails** option found on 
-**Administer > CiviMail > CiviMail Component Settings**
+administrator can enable the **CiviCRM: edit inbound email basic information** 
+or the **CiviCRM: edit inbound email basic information and content** permissions
+for the roles that require it.
+
+**CiviCRM: edit inbound email basic information** will allow users to edit every
+field of the activity, except the original message, stored int the activity's 
+details.
+
+**CiviCRM: edit inbound email basic information and content** will allow users
+to edit every field of the activity, including the original message's content.


### PR DESCRIPTION
Overview
----------------------------------------
On some business cases, it may be required to be able to edit an activity type of 'Inbound E-mail', for example, to add an observation or edit some custom fields to implement some kind of workflow. However, this is currently not possible, as the prohibition for this type of activities is hard-coded in several parts within CiviCRM.

This new option to allow users to edit activities of Inbound Email type is being added on this PR:
https://github.com/civicrm/civicrm-core/pull/12445