### PR TITLE
CRM-21498: Add Documentation of Linked Case Status Change Functionality

### DIFF
--- a/docs/case-management/everyday-tasks.md
+++ b/docs/case-management/everyday-tasks.md
@@ -373,13 +373,18 @@ To change the status of a case:
 4.  This will open the **Change Case Status** form (an activity with an
     additional field called Case Status).
 5.  Set the case status to the new status.
-6.  Modify the other the fields as you would when editing an activity in
+6.  If the case has any linked cases, the list of linked cases will be shown on 
+    a table within the form. If you need to update the status of linked cases too, 
+    you can click the checkbox for **Update Linked Cases Status**.
+7.  Modify the other the fields as you would when editing an activity in
     a case. Make sure to set the **Status** field. It is required, but
     not set by default. 
-7.  Click **Save** to return to the case page, with a message stating
+8.  Click **Save** to return to the case page, with a message stating
     that the Change Case Status Activity has been created.
 
 An activity is recorded because when a case status changes, it changed
 because something happened. It is usually equally as important to record
 the *who* and the *why* as well as the *what*. This behaviour is
-consistent throughout CiviCase.
+consistent throughout CiviCase. This will also happen for linked cases, if the
+**Update Linked Cases Status** checkbox was checked and the linked case's status
+was different to the new status of the parent case.


### PR DESCRIPTION
Overview
----------------------------------------
On some occasions, it might be useful when changing a case's status, to have all linked cases change status too.  For this, we could have a checkbox on the case status change form so that when it is checked, all related cases change to the same status.

We will only take into account directly linked cases (i.e. L1 link) and not the linked cases of the linked cases (i.e. ignore any nesting).

If the status of one or more linked cases is the same as the status the user is changing to (eg. the user is changing the status from ongoing to resolved and one of the linked cases is already resolved), we will still list the case in the case list, but there will be no action taken (ie. no activity should be created for the status change).

Before
----------------------------------------
When changing a case's status, if linked cases had to be changed too, you'd had to go to each case independently and change it's status manually.

![image](https://user-images.githubusercontent.com/21999940/33428728-04f5f158-d598-11e7-8fc6-329f78e5728d.png)

After
----------------------------------------
When changing a case's status, if it has any linked cases, a checkbox will appear on the form so the user can choose to update linked cases statuses too.

![image](https://user-images.githubusercontent.com/21999940/33428813-5569fb70-d598-11e7-85dc-de7b593a3e4f.png)

Comments
----------------------------------------
This functionality is being added to CiviCRM core on this PR:
https://github.com/civicrm/civicrm-core/pull/11350