### PR TITLE
CRM-21520: Document Bulk Add Contacts to Case Search Action

### DIFF
--- a/docs/case-management/everyday-tasks.md
+++ b/docs/case-management/everyday-tasks.md
@@ -229,6 +229,20 @@ the list of case activities in the proper sequence. This provides an
 audit trail of case-related communications, and ensures that the case
 story is complete. 
 
+## Bulk add contacts to a case with a specific role
+
+On some occasions it might be useful to add several contacts to a case with
+a specific role. To do this, an action is available on contacts search results
+views. To add multiple contacts to a case in bulk:
+
+1. Perform a search on Contacts.
+2. Select the contacts that need to be added to a case from the search results.
+3. Choose the **Add to case as role** action.
+4. Use the shown form to choose the case to which contacts have to be assigned 
+and the role the contacts will have in the case.
+5. Click **Submit** to add the contacts to the case, or **Cancel** to go back 
+to search results.
+
 ## Finding activities within a case
 
 You may need to find a specific activity within a case, for reference or


### PR DESCRIPTION
Overview
----------------------------------------
From search results, the user can do a set of actions. In this actions menu, we need to add a new option: "Add contacts to Case". Once the user selects this option, they will see a form where they can select a case (an existing case) and also assign a case role to all selected users.

![screen shot 2017-12-04 at 12 25 08 1](https://user-images.githubusercontent.com/21999940/33607912-9bb3e504-d990-11e7-8685-38c5993ffa40.png)

Before
----------------------------------------
It was not possible to add contacts to a case in bulk.

After
----------------------------------------
Added functionality:
- Added action to search results list of actions.
- Created Form to show selection combos to choose case and role.
- Implemented postProcess logic to add contacts to the selected case with the selected role.

CiviCRM Core PR:
https://github.com/civicrm/civicrm-core/pull/11371