### PR TITLE
Cross Reference for "Organising Your Data"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+site

--- a/docs/common-workflows/importing-data-into-civicrm.md
+++ b/docs/common-workflows/importing-data-into-civicrm.md
@@ -13,8 +13,9 @@ in the final section of this chapter.
 ## Considerations before importing
 
 For more details on how to think about your data before importing into
-CiviCRM, please read the section on "Organizing your data", especially
-"Mapping your data into CiviCRM".
+CiviCRM, please read the section on 
+["Organizing your data"](/organising-your-data/overview.md), especially
+["Mapping your data into CiviCRM"](/organising-your-data/mapping-your-data/).
 
 ## Preparing to import data
 


### PR DESCRIPTION
## Before

Under [Considerations before importing](https://docs.civicrm.org/user/en/latest/common-workflows/importing-data-into-civicrm/#considerations-before-importing) there is a line that references another section:

> please read the section on "Organizing your data"

However it doesn't link to it

## After

The line has an internal link to it

![image](https://user-images.githubusercontent.com/6374064/37803517-17f0a180-2e27-11e8-95a1-273e3492ee8f.png)

Fixes #174 

## Notes

I know it's not related to this, but I think it makes sense to add the default build directory to .gitignore. This will help keep the working directory clean and avoid anyone accidentally committing files from there.