### PR TITLE
Fix list formatting to resolve #111

### DIFF
--- a/docs/contributions/online-contributions.md
+++ b/docs/contributions/online-contributions.md
@@ -105,12 +105,13 @@ This is covered in detail in  [Memberships](../memberships/online-membership-sig
 ![online contribution thank you and receipt set up](../img/civicontribute-online-thank-you-and-receipt.png)
 
 Here you can:
- -  Customise the Thank-you page that will be displayed to your
+
+* Customise the Thank-you page that will be displayed to your
 contributors. Contributors are sure to appreciate a title such as "Thanks
 for your contribution" with a re-statement of how their contribution will be
 used. (If you don't visit this tab the "Thank-you" page will just have the
 same title as the contribution page.)
- -  Decide whether or not to have a receipt automatically emailed at the time
+* Decide whether or not to have a receipt automatically emailed at the time
 of the contribution. If you do decide to send a receipt then the fields
 under "Email Receipt to Contributor" will appear. The receipt message is
 specifically for the contribution page you are creating and will be added to


### PR DESCRIPTION
@joannechester @seamuslee001 

This is a follow up to #259 

Unfortunately your fix didn't do it. Sorry! 

Here's a screenshot showing live vs local with my fix applied. 

<img width="429" alt="image" src="https://user-images.githubusercontent.com/42411/37803839-824cf33c-2e07-11e8-83bc-aa2d593f68ec.png">

The list formatting syntax is very picky in MkDocs. The reason it wasn't working was that there needs to be a blank line between a paragraph an a list. This has come up a bunch of times before for other people, and it has to do with the fact that different markdown platforms have slightly different rules for how they parse markdown. 

I also changed the syntax to use `*` instead of `-` since that's part of our [soft standard](https://docs.civicrm.org/dev/en/latest/documentation/markdown/#standards) and to not use whitespace before the bullet (which is really the best way to do it but will take longer to explain why). Note that a lot of the content in the User Guide has lists that don't follow this exact syntax, and that's mostly okay if the end product displays fine, but a lot of the markdown in the User Guide (I believe) was auto generated from Pandoc which doesn't produce the cleanest markdown. 

I know this is really getting into the weeds a bit over a tiny issue, but I figured it'd be worth explaining a bit 