### PR TITLE
Replace "Note", "Warning", "Caution" etc with admonitions

### DIFF
--- a/docs/case-management/everyday-tasks.md
+++ b/docs/case-management/everyday-tasks.md
@@ -290,8 +290,9 @@ sent back to the case page, or **Cancel** to discard your work.
 4.  Fill out the activity form. The Client field will be pre-populated
     with the case's client data.
 
-Note: the drop-down list of activities is configurable. Refer to the
-instructions for Activity Lists in the set-up chapter
+!!! note
+    The drop-down list of activities is configurable. Refer to the
+    instructions for Activity Lists in the set-up chapter
 
 ### Adding a set of activities
 

--- a/docs/case-management/what-you-need-to-know.md
+++ b/docs/case-management/what-you-need-to-know.md
@@ -189,11 +189,12 @@ completion of activities in your case are outside your control. However,
 as the activities are created progressively it will not provide the same
 at-a-glance overview of the case that a timeline does. 
  
-**NOTE:** If you want to use both a timeline and a sequence in the same
-case you must make sure that there is no overlap in activity types
-between the two. For example, you cannot include the activity type of
-"Meeting" in both a timeline and the sequence within the same case as
-this will create problems. 
+!!!note
+    If you want to use both a timeline and a sequence in the same
+    case you must make sure that there is no overlap in activity types
+    between the two. For example, you cannot include the activity type of
+    "Meeting" in both a timeline and the sequence within the same case as
+    this will create problems. 
 
 ## Case Roles and Relationships 
 

--- a/docs/common-workflows/deduping-and-merging.md
+++ b/docs/common-workflows/deduping-and-merging.md
@@ -201,8 +201,9 @@ may then continue to assess and merge the remaining duplicates manually.
 
 ![screenshot](../img/CiviCRM_dedupe_batchmerge.PNG)
 
-**WARNING:** before you begin to consider using batch dedupe, please
-take note of the following:
+!!! warning
+    before you begin to consider using batch dedupe, please take note of 
+    points below
 
 1.  This feature is intended for use with large data sets that have
     strictly managed field structures. If you have a small database with

--- a/docs/common-workflows/deduping-and-merging.md
+++ b/docs/common-workflows/deduping-and-merging.md
@@ -202,21 +202,12 @@ may then continue to assess and merge the remaining duplicates manually.
 ![screenshot](../img/CiviCRM_dedupe_batchmerge.PNG)
 
 !!! warning
-    before you begin to consider using batch dedupe, please take note of 
-    points below
+    Before you begin to consider using batch dedupe, please take note of 
+    points below.
 
-1.  This feature is intended for use with large data sets that have
-    strictly managed field structures. If you have a small database with
-    only a few duplicates, we recommend you merge them manually using
-    your own judgement.
-2.  Once merged, the links between the duplicate contact and records
-    elsewhere in the system will be transferred to the original contact
-    (e.g. event participant records, groups, tags, contributions,
-    activities, cases and memberships). You will NOT be able to reverse
-    this change.
-3.  Duplicate records, once merged, will be deleted and are not
-    recoverable. We strongly recommend backing up your data before
-    running a batch merge.
+    *  This feature is intended for use with large data sets that have strictly managed field structures. If you have a small database with only a few duplicates, we recommend you merge them manually using your own judgement.
+    *  Once merged, the links between the duplicate contact and records elsewhere in the system will be transferred to the original contact (e.g. event participant records, groups, tags, contributions, activities, cases and memberships). You will NOT be able to reverse this change.
+    *  Duplicate records, once merged, will be deleted and are not recoverable. We strongly recommend backing up your data before running a batch merge.
 
 ## A multi-stage deduping process
 
@@ -247,5 +238,5 @@ disruption.
 
 1.  Select the duplicate contacts from your search results by clicking
     the check box at the left side of each record.
-2.  Select **Merge Contacts** from the ** Actions** menu.
+2.  Select **Merge Contacts** from the **Actions** menu.
 3.  Follow the normal steps for merging duplicate contacts.

--- a/docs/contributions/finding-and-viewing-contributions.md
+++ b/docs/contributions/finding-and-viewing-contributions.md
@@ -68,7 +68,7 @@ in order to be returned, so the more criteria you enter, the narrower the search
  contributions and updating their status to canceled provides a better audit
  trail, but there may be situations where you do want to delete, such as a
  contribution entered on the wrong contact's record.
- - **Export contributions**: NOTE: This is an export of contributions.  If you
+ - **Export contributions**: This is an export of contributions.  If you
  choose to export multiple contributions from the same contact you will end up
  with one row for each contribution in your export file. If you want to do
  searches that return one result per contact, use the contact advanced search.

--- a/docs/contributions/key-concepts-and-configurations.md
+++ b/docs/contributions/key-concepts-and-configurations.md
@@ -91,7 +91,8 @@ accounting software package you will need the accounting code (without
 extra or missing spaces).  If you are using Quickbooks you will also need the
 account type code.
 
-NOTE: Changing the financial account name will also change the financial type name.
+!!!note
+    Changing the financial account name will also change the financial type name.
 
 ## **Payment processors**
 
@@ -119,10 +120,10 @@ Navigate to **Administer > CiviContribute > Accepted Credit Cards** to
 edit existing acceptable credit cards or define a new option through
 **Add Accepted Credit Card**.
 
-Note: If billing information is collected on the payment processor's website
-then you will need to configure accepted credit cards/payment methods on that
-site.
-
+!!!note
+    If billing information is collected on the payment processor's website
+    then you will need to configure accepted credit cards/payment methods on 
+    that site.
 
 ## Data needs and fields
 

--- a/docs/contributions/key-concepts-and-configurations.md
+++ b/docs/contributions/key-concepts-and-configurations.md
@@ -91,7 +91,7 @@ accounting software package you will need the accounting code (without
 extra or missing spaces).  If you are using Quickbooks you will also need the
 account type code.
 
-!!!note
+!!! note
     Changing the financial account name will also change the financial type name.
 
 ## **Payment processors**
@@ -120,7 +120,7 @@ Navigate to **Administer > CiviContribute > Accepted Credit Cards** to
 edit existing acceptable credit cards or define a new option through
 **Add Accepted Credit Card**.
 
-!!!note
+!!! note
     If billing information is collected on the payment processor's website
     then you will need to configure accepted credit cards/payment methods on 
     that site.

--- a/docs/contributions/manual-entry-of-contributions.md
+++ b/docs/contributions/manual-entry-of-contributions.md
@@ -97,12 +97,14 @@ Enter the following information:
     view in the batch entry grid screen (Contribution Batch Entry
     profile, Membership Batch Entry profile or Pledge Payment Batch
     Entry profile)
--   **Status**: the default will be “Open” (note: once a batch has a
-    “closed status”, the batch will no longer be editable)
+-   **Status**: the default will be “Open”
 -   **Number of items**: total of payment items in the batch (required
     field)
 -   **Total amount**: total amount of all the payment items in the batch
     (required field)
+
+!!!note
+    Once a batch has a “closed status”, the batch will no longer be editable
 
 You can edit or delete Batch information later on by going back to the
 **Bulk Data Entry** screen, then clicking on **Edit** or **Delete** next to
@@ -121,15 +123,18 @@ line.
 There are eight fields that appear for all batches:
 
 -  **Contact**. In this column you can:
-    -   start entering the name of an existing contact and CiviCRM will
+    -   Start entering the name of an existing contact and CiviCRM will
     return a list of potential contact names for you to select, OR
-    -   create a new contact by clicking the drop-down box for “-create new
+    -   Create a new contact by clicking the drop-down box for “-create new
     contact-“ and selecting the type of contact you want to create: **New
     Individual**, **New Organization**, or **New Household** and enter the
     information about the contact here.
-    Note: If contact information such as phone number or email address
-are included in the grid profile, those values will be populated for
-an existing contact and can be updated as needed.
+    
+    !!!note
+        If contact information such as phone number or email address
+        are included in the grid profile, those values will be populated for
+        an existing contact and can be updated as needed.
+
 -   **Financial Type**
 -   **Amount**
 -   **(Payment) Status**
@@ -253,11 +258,12 @@ information you want to collect for these contacts:
   use profiles, see the chapter called “Profiles” in the “User
   Interface” section*.
 
-**TIP:** Reserved profiles for **New Individual, New Organization**,
-and **New Household**, are used in other areas of CiviCRM. Be aware
-that if you alter these profiles for use with **Batches**, these same
-changes you’ve made will also appear on other screens where you have the
-option to create a new contact inline.
+!!! tip
+    Reserved profiles for **New Individual, New Organization**,
+    and **New Household**, are used in other areas of CiviCRM. Be aware
+    that if you alter these profiles for use with **Batches**, these same
+    changes you’ve made will also appear on other screens where you have the
+    option to create a new contact inline.
 
   ![screenshot](../img/CiviCRM-Contributions-SetUp-new-individual-profile.jpg)
 

--- a/docs/contributions/manual-entry-of-contributions.md
+++ b/docs/contributions/manual-entry-of-contributions.md
@@ -82,9 +82,9 @@ The details for each step are listed below.
 
 ### 1. Create a new batch for data entry
 
-  Create a new batch to hold the multiple payments you want to record:
+Create a new batch to hold the multiple payments you want to record:
 
-  From the menu, click on **Contributions > Batch Data Entry** or
+From the menu, click on **Contributions > Batch Data Entry** or
 **Membership > Batch Data Entry**.
 
 ![screenshot](../img/New%20Data%20Entry.png)
@@ -103,7 +103,7 @@ Enter the following information:
 -   **Total amount**: total amount of all the payment items in the batch
     (required field)
 
-!!!note
+!!! note
     Once a batch has a “closed status”, the batch will no longer be editable
 
 You can edit or delete Batch information later on by going back to the
@@ -130,7 +130,7 @@ There are eight fields that appear for all batches:
     Individual**, **New Organization**, or **New Household** and enter the
     information about the contact here.
     
-    !!!note
+    !!! note
         If contact information such as phone number or email address
         are included in the grid profile, those values will be populated for
         an existing contact and can be updated as needed.

--- a/docs/contributions/online-contributions.md
+++ b/docs/contributions/online-contributions.md
@@ -125,21 +125,23 @@ regardless of whether you include any other fields in your profile(s).
     copy an existing profile or create a new profile.
     When you edit or create a new profile you will use the profile drag
     and drop interface pictured here.
-
     ![screenshot](../img/Contribution-page-edit-profile2.gif)
-
-    WARNING: If you modify an existing profile whilst configuring your
-    Contribution page, the changes you make will apply everywhere that
-    profile is being used. So unless an existing profile **exactly**
-    matches your requirements you should copy the profile, then rename
-    and edit the copy as required.
+    
+    !!! warning
+        If you modify an existing profile whilst configuring your
+        Contribution page, the changes you make will apply everywhere that
+        profile is being used. So unless an existing profile **exactly**
+        matches your requirements you should copy the profile, then rename
+        and edit the copy as required.
+        
 3.  Click **Save** or **Save and Done** or **Save and Next**.
 
-Note: If you include a profile with a Home Address at the top of the
-page, CiviCRM automatically generates a checkbox on the front end form
-which allows the user to indicate that their Billing Address and Home
-Address are the same. (If the Home Address profile is included at the
-bottom of the page, this checkbox will not be generated).
+!!! note
+    If you include a profile with a Home Address at the top of the
+    page, CiviCRM automatically generates a checkbox on the front end form
+    which allows the user to indicate that their Billing Address and Home
+    Address are the same. (If the Home Address profile is included at the
+    bottom of the page, this checkbox will not be generated).
 ![Include profile top of page listbox, and include profile bottom of page listbox.](../img/Profiles-HomeAddress.jpg)
 
 It is highly recommended that Contribution Pages include a CAPTCHA (reCAPTCHA in the case of CiviCRM).  You can add reCAPTCHA to a profile you include and it will be included on the Contribution Page.

--- a/docs/contributions/online-contributions.md
+++ b/docs/contributions/online-contributions.md
@@ -136,13 +136,14 @@ regardless of whether you include any other fields in your profile(s).
         
 3.  Click **Save** or **Save and Done** or **Save and Next**.
 
-!!! note
+!!! note "Home Address vs Billing Address"
     If you include a profile with a Home Address at the top of the
     page, CiviCRM automatically generates a checkbox on the front end form
     which allows the user to indicate that their Billing Address and Home
     Address are the same. (If the Home Address profile is included at the
     bottom of the page, this checkbox will not be generated).
-![Include profile top of page listbox, and include profile bottom of page listbox.](../img/Profiles-HomeAddress.jpg)
+    
+    ![Include profile top of page listbox, and include profile bottom of page listbox.](../img/Profiles-HomeAddress.jpg)
 
 It is highly recommended that Contribution Pages include a CAPTCHA (reCAPTCHA in the case of CiviCRM).  You can add reCAPTCHA to a profile you include and it will be included on the Contribution Page.
 

--- a/docs/email/everyday-tasks.md
+++ b/docs/email/everyday-tasks.md
@@ -60,11 +60,12 @@ sender. The activity record will also list all the other message
 recipients. Unlike with mass mailing (see below) there is no one place
 where all emails sent via the Send Email function are listed.
 
-**Note:** If a message is sent to multiple recipients, each recipient
-will see only their own email address in the To field. Because the
-recipients don't see who else received the email, you might want to
-mention whom you are sending it to in the text of your mail (for
-instance: "TO: Members of the board, staff")
+!!! note
+    If a message is sent to multiple recipients, each recipient
+    will see only their own email address in the To field. Because the
+    recipients don't see who else received the email, you might want to
+    mention whom you are sending it to in the text of your mail (for
+    instance: "TO: Members of the board, staff")
 
 ## Inserting an image in an email
 

--- a/docs/email/mass-mailings-using-civimail.md
+++ b/docs/email/mass-mailings-using-civimail.md
@@ -172,8 +172,8 @@ is displayed whichever tab is selected. Within this panel are the options to:
       useful to ensure things like font consistency, basic layout and
       color.
 
-  -  Send a test email to a single email address (Note: If the email address
-    does not already exist in CiviCRM a new contact record will be created.)
+  -  Send a test email to a single email address. If the email address
+    does not already exist in CiviCRM a new contact record will be created.
   -  Send a test email to a an existing group in CiviCRM.
 
       The test mailing will fill in all the Tokens and include any attachments you are planning to send.
@@ -247,18 +247,19 @@ has unsubscribed from one of the mailing lists.
     means that all links will be overwritten with custom links
     containing your domain name.
 
-    **Note for HTML mail:** Some phishing filters may mark links that are
-    displayed differently in HTML code and in the text as unsafe. It is
-    therefore best not to use something like ```
-    <a href="http://google.com">http://Google.com</a>```
-     but rather use    ```
-     <a href="http://google.com">click here to go to Google</a>```
-     instead.
+    !!! note "Note for HTML mail"
+        Some phishing filters may mark links that are displayed 
+        differently in HTML code and in the text as unsafe. It is therefore 
+        best not to use something like  
+        `<a href="http://google.com">http://Google.com</a>`
+        but rather use  
+        ` <a href="http://google.com">click here to go to Google</a>` instead.
 
-    **Note for Plain Text email:** If you use short, user-friendly URLs
-    in your email, they will all be overwritten with long links
-    containing the name of your site and a long code looking like this
-    http://yoursite.com/sites/all/modules/civicrm/extern/url.php?u=529&qid=29011.
+    !!! note "Note for Plain Text Email"
+        If you use short, user-friendly URLs, they will all be overwritten 
+        with long links containing the name of your site and a long code 
+        looking like this 
+        http://yoursite.com/sites/all/modules/civicrm/extern/url.php?u=529&qid=29011.
 
 -   **Track Opens:** This option allows you to track how many people
     opened the email you received. However, there are limitations to the
@@ -340,8 +341,10 @@ Mass mailings can be found in one of three areas accessible via the
  **Save & Continue Later** or simply abandon a message after some
  steps, you can continue working on it by clicking on the
  **Continue** link next to the message listed here.
- (**Note:** Mailings started based on search results will not have the
- Continue link listed.)
+
+!!! note
+    Mailings started based on search results will not have the continue link 
+    listed
 
  You can also **Delete** draft messages here.
 

--- a/docs/email/reports-and-analysis.md
+++ b/docs/email/reports-and-analysis.md
@@ -26,7 +26,7 @@ intended to be sent to.
 **Tracked Opens** shows the number of people that CiviCRM thinks have
 opened the email *if you have chosen to track opens*.
 
-!!! info
+!!! info "How Open Tracking works"
     In the world of email, there is no 100% reliable way of
     knowing when someone has opened an email. CiviCRM uses a trick that is
     common amongst mass mailers &mdash; it embeds a small image with a unique name

--- a/docs/email/reports-and-analysis.md
+++ b/docs/email/reports-and-analysis.md
@@ -26,19 +26,20 @@ intended to be sent to.
 **Tracked Opens** shows the number of people that CiviCRM thinks have
 opened the email *if you have chosen to track opens*.
 
-**Note:** In the world of email, there is no 100% reliable way of
-knowing when someone has opened an email. CiviCRM uses a trick that is
-common amongst mass mailers &mdash; it embeds a small image with a unique name
-in each email. When a client views the email and downloads the image,
-CiviCRM knows that they have read the email. Because this technique is
-common, to protect people's privacy, most email clients ask users to
-confirm whether they want to download images in emails. Hence your
-report really tells you the number of people who downloaded the images;
-the actual number of readers is higher than the number reported. Tracked
-opens statistics should be taken as indicative, rather than accurate. In
-our experience, a 30% reported opening rate can be considered good. This
-is obviously different for each organisation and each group you send
-emails to.
+!!! info
+    In the world of email, there is no 100% reliable way of
+    knowing when someone has opened an email. CiviCRM uses a trick that is
+    common amongst mass mailers &mdash; it embeds a small image with a unique name
+    in each email. When a client views the email and downloads the image,
+    CiviCRM knows that they have read the email. Because this technique is
+    common, to protect people's privacy, most email clients ask users to
+    confirm whether they want to download images in emails. Hence your
+    report really tells you the number of people who downloaded the images;
+    the actual number of readers is higher than the number reported. Tracked
+    opens statistics should be taken as indicative, rather than accurate. In
+    our experience, a 30% reported opening rate can be considered good. This
+    is obviously different for each organisation and each group you send
+    emails to.
 
 Don't focus too much on the absolute numbers, but rather use them as a
 way of comparing different mailings you send. You might want to use them

--- a/docs/email/scheduled-reminders.md
+++ b/docs/email/scheduled-reminders.md
@@ -77,8 +77,11 @@ general process is:
     see *Limiting or adding to your recipient list* in this chapter.
 8.  Choose to send your reminder as an email, an SMS or either depending
     on the preferred method(s) of communications for the contact.
-    NOTE: The SMS option will only be available if you have
-    [set up an SMS Gateway](../sms-text-messaging/set-up)
+    
+    !!! note
+        The SMS option will only be available if you have 
+        [set up an SMS Gateway](../sms-text-messaging/set-up)
+    
 9.  Compose your message. You can use Message Templates or write the
     message from scratch.
 10. Click **Save** when you are are done.
@@ -86,10 +89,11 @@ general process is:
 Reminders can be edited, disabled, or deleted from **Administer >
 Communications > Schedule Reminders**.
 
-IMPORTANT: Your system administrator will need to ensure that the Send
-Scheduled Reminders scheduled job is enabled and runs at least once a
-day. Refer to the [Scheduled Jobs](https://docs.civicrm.org/sysadmin/en/latest/setup/jobs/)
-section for configuration details.  
+!!! warning
+    Your system administrator will need to ensure that the Send
+    Scheduled Reminders scheduled job is enabled and runs at least once a
+    day. Refer to the [Scheduled Jobs](https://docs.civicrm.org/sysadmin/en/latest/setup/jobs/)
+    section for configuration details.  
 
 ## Using scheduled reminders for contacts
 
@@ -190,8 +194,9 @@ membership expires:
 What information you should include in a renewal email will be discussed
 in *Renewals* in the *CiviMember* section.
 
-Note: If a member renews, they will receive their next reminder 5 days before
-their new Membership End Date.
+!!! note
+    If a member renews, they will receive their next reminder 5 days before
+    their new Membership End Date.
 
 ### Chasing members who have not sent membership payments
 

--- a/docs/email/set-up.md
+++ b/docs/email/set-up.md
@@ -48,12 +48,13 @@ To create a **Smart Group**:
     description, and make the Smart Group a Mailing List.
 5.  Click **Save Smart Group**.
 
-**Note:** You can also create a Smart Group based on a Participant
-search. However, the Smart Group save page will not offer you the option
-to make this group a Mailing List. To make this Smart Group available to
-CiviMail, you must change its settings through **Contacts > Manage
-Groups**. This same thing happens if you use the Advanced Search and
-choose Event Participants under "Display results as."
+!!! info
+    You can also create a Smart Group based on a Participant
+    search. However, the Smart Group save page will not offer you the option
+    to make this group a Mailing List. To make this Smart Group available to
+    CiviMail, you must change its settings through **Contacts > Manage
+    Groups**. This same thing happens if you use the Advanced Search and
+    choose Event Participants under "Display results as."
 
 You cannot create smart groups based on Membership, Contributions or
 Pledge searches, or based on results of an Advanced Search if the
@@ -155,9 +156,11 @@ confirm their subscription. Until they click the confirmation link in
 the email, their contact information will appear in CiviCRM with their
 group subscription set to Pending. When they confirm, CiviCRM will
 automatically change their group subscription status to Added and they
-will be sent a welcome message. (Note: When users subscribe to multiple
-groups at once, a confirmation email is sent for each group
-separately.)
+will be sent a welcome message.
+
+!!! note
+    When users subscribe to multiple groups at once, a confirmation email is 
+    sent for each group separately.
 
 ## Scheduled jobs and cron jobs
 

--- a/docs/events/keeping-track-of-events-and-participants.md
+++ b/docs/events/keeping-track-of-events-and-participants.md
@@ -215,9 +215,10 @@ usage.
 **Reserved?:** Select this option if you want to ensure that admin users
 do not accidentally delete the badge layout.
 
-Note: You will not be able to preview the badge layout unless at least
-one event has been created and at least one participant has been
-registered.
+!!! note
+    You will not be able to preview the badge layout unless at least
+    one event has been created and at least one participant has been
+    registered.
 
 **Printing Name Badges**
 

--- a/docs/events/online-event-registration.md
+++ b/docs/events/online-event-registration.md
@@ -103,11 +103,12 @@ new profile with fewer fields. If you choose not to collect email
 addresses, be sure to uncheck the option "Send confirmation email?" at
 the bottom!
 
-WARNING: If you modify an existing profile whilst configuring your
-Online Registration page, the changes you make will apply everywhere
-that profile is being used. So unless an existing profile **exactly**
-matches your requirements you should copy the profile, then rename and
-edit the copy as required. 
+!!! warning
+    If you modify an existing profile whilst configuring your
+    Online Registration page, the changes you make will apply everywhere
+    that profile is being used. So unless an existing profile **exactly**
+    matches your requirements you should copy the profile, then rename and
+    edit the copy as required. 
 
 If the profile you require does not already exist, you can create it
 without leaving the Online Registration configuration page. The drag and

--- a/docs/events/repeating-events.md
+++ b/docs/events/repeating-events.md
@@ -17,11 +17,12 @@ the Repetition Start Date and Excluded Dates.
 
 ![screenshot](../img/repeating_event_page.png)
 
-**Note:** If you would like your Scheduled Reminders to repeat, make
-sure you have setup Scheduled Reminders on the Event that you are
-repeating, you can edit this later. It is also recommend that you do not
-setup your reminders to repeat on specific days, but rather have them
-sent two weeks or a few days before the Event.
+!!! note
+    If you would like your Scheduled Reminders to repeat, make
+    sure you have setup Scheduled Reminders on the Event that you are
+    repeating, you can edit this later. It is also recommend that you do not
+    setup your reminders to repeat on specific days, but rather have them
+    sent two weeks or a few days before the Event.
 
 Once you have filled out all the appropriate fields click
 **Save,**to save your selection**.**You will have a popup window that

--- a/docs/initial-set-up/addresses.md
+++ b/docs/initial-set-up/addresses.md
@@ -172,7 +172,10 @@ staffed from 7:00AM to 11:00PM Eastern Time
 
 > This unique User ID cannot be shared with others outside your organization, nor is it to be packaged and distributed or sold to other individuals, businesses or e-commerce web site entities.> If the U.S. Postal Service discovers use of the same User ID from more than one web site, all users will be subject to loss of access to the USPS production server
 
-**Warning: CiviCRM invokes the address standardization API even when doing contact imports. Be careful to either turn off the standardization feature when doing imports, or to limit yourself to imports containing only a addresses.**
+!!! warning
+    CiviCRM invokes the address standardization API even when doing contact 
+    imports. Be careful to either turn off the standardization feature when 
+    doing imports, or to limit yourself to imports containing only a addresses
 
 What some may be viewing as technical problems may just be the result of being caught violating the terms of service.
 

--- a/docs/initial-set-up/installation-and-basic-set-up.md
+++ b/docs/initial-set-up/installation-and-basic-set-up.md
@@ -334,13 +334,16 @@ House" or "Volunteering Opportunities").
     box on the navigation menu. The contact name is always included.
 -   **Contact Reference Options** - Selected fields will be displayed in
     autocomplete dropdown search results for 'Contact Reference' custom
-    fields. Contact Name is always included. Note: You must assign
-    'access contact reference fields' permission to the anonymous role
-    if you want to use custom contact reference fields in profiles on
-    public pages. For most situations, you should use the 'Limit List to
-    Group' setting when configuring a contact reference field which will
-    be used in public forms to prevent exposing your entire contact
-    list.
+    fields. Contact Name is always included. 
+    
+    !!! note
+        You must assign 'access contact reference fields' permission to the 
+        anonymous role if you want to use custom contact reference fields in 
+        profiles on public pages. For most situations, you should use the 
+        'Limit List to Group' setting when configuring a contact reference 
+        field which will be used in public forms to prevent exposing your 
+        entire contact list.
+        
 -   **Autocomplete Results**- This specifies the maximum number of
     contacts to show at a time when typing in an autocomplete field. The
     default is 10.

--- a/docs/membership/finding-and-viewing-memberships.md
+++ b/docs/membership/finding-and-viewing-memberships.md
@@ -29,12 +29,14 @@ as Delete, Edit, Export, Send Email to Contacts.
 ### Viewing A Contact's Membership Records
 
 Another way to view membership records is by viewing a specific
-contact's record and looking at the Membership tab. Note:If a contact's
-membership is "pending", the membership will show up when the tab is
-clicked but it will NOT be counted in the number on the tab.
+contact's record and looking at the Membership tab. 
 
--   After finding the contact you wish to manage, click the "Membership"
-    tab to view a summary of the contact's membership records.
+!!! note
+    If a contact's membership is "pending", the membership will show up when 
+    the tab is clicked but it will NOT be counted in the number on the tab.
+
+After finding the contact you wish to manage, click the "Membership" tab to 
+view a summary of the contact's membership records.
 
 ![image](../img/CiviCRM_update-CiviCore-Contact_MembershipTabs-en.jpg)
 

--- a/docs/membership/online-membership-sign-up.md
+++ b/docs/membership/online-membership-sign-up.md
@@ -197,8 +197,10 @@ process.
 The profiles tab allows you to select an already existing profile to
 include on your membership page, and if you have permission, to edit an
 existing profile or create a new profile to be included on this page.
-**WARNING:** If you edit an existing profile here, it will be changed in
-all places where that profile is used.
+
+!!! warning
+    If you edit an existing profile here, it will be changed in all places 
+    where that profile is used.
 
 ###Premiums tab
 

--- a/docs/organising-your-data/contacts.md
+++ b/docs/organising-your-data/contacts.md
@@ -311,8 +311,9 @@ was changed.
 
 ![Contact_ChangeLog](../img/CiviCRM_update-CiviCore-Contact_ChangeLog-en.jpg "Contact_ChangeLog")
 
-Note: Administrators can use the Contact Logging Report to get detailed
-information on changes to contact records (who, what and when).
+!!! tip
+    Administrators can use the Contact Logging Report to get detailed
+    information on changes to contact records (who, what and when).
 
 ## Adding contacts
 

--- a/docs/organising-your-data/groups-and-tags.md
+++ b/docs/organising-your-data/groups-and-tags.md
@@ -258,7 +258,8 @@ the parts before you try to join them together. In this case, you must
 set up the required Groups, Custom Data Groups, Profiles and Roles
 before you can use them in ACL.
 
-Note that ACL support for Joomla was introduced in Joomla version 1.6.
+!!! note
+    ACL support for Joomla was introduced in Joomla version 1.6.
 
 ## Removing versus deleting contacts from groups
 

--- a/docs/organising-your-data/profiles.md
+++ b/docs/organising-your-data/profiles.md
@@ -642,8 +642,8 @@ To create a profile for this purpose:
 4.  Add the fields you want people to be able to edit from their Drupal
     My Account page.
 
-Note: the profile must include only fields related to the Individual
-contact type.
+!!! warning
+    The profile must include only fields related to the Individual contact type.
 
 **New account creation during profile sign-up**
 

--- a/docs/petition/set-up.md
+++ b/docs/petition/set-up.md
@@ -31,7 +31,7 @@ for each individual who signs the petition.
     a profile with fields for the contact information you want to
     collect, such as First Name, Last Name, and Email. You may want to
     make some of these fields required so you capture enough information
-    to communicate with signers at a later date. Note: you must collect
+    to communicate with signers at a later date. You must collect
     at minimum an email address in the contact profile, because the
     Petition feature will send an email to the signer of the petition to
     prompt them to verify their email address. Only those verified email

--- a/docs/pledges/everyday-tasks.md
+++ b/docs/pledges/everyday-tasks.md
@@ -46,12 +46,14 @@ Enter the following information:
 -   **Batch Name**: CiviCRM will create a default batch name ("Batch N" + open date), which you can edit (required field)
 -   **Type**: Select **Pledge Payment**. This selects the appropriate
     reserved profile to view in the batch entry grid screen. 
--   **Status**: the default will be “Open” (note: once a batch has a
-    “closed status”, the batch will no longer be editable)
+-   **Status**: the default will be “Open”
 -   **Number of items**: total of payment items in the batch (required
     field)
 -   **Total amount**: total amount of all the payment items in the batch
     (required field) 
+
+!!! note
+    Once a batch has a “closed status”, the batch will no longer be editable
 
 You can edit or delete Batch information by going back to the **Bulk
 Data Entry** screen then clicking on **Edit** or **Delete** next to the
@@ -70,16 +72,17 @@ follows;
 
 -   **Contact.** You can:
 
-    - start entering the name of an existing contact and CiviCRM will
+    - Start entering the name of an existing contact and CiviCRM will
     return a list of potential contact names for you to select, OR 
-    -   create a new contact by clicking the drop-down box for “-create new
+    - Create a new contact by clicking the drop-down box for “-create new
     contact-“ and selecting the type of contact you want to create:**New
     Individual, New Organization**, or **New Household** and enter the
     information about the contact here. 
 
-    Note:  If contact information such as phone number or email address
-    are included in the grid profile, those values will be populated for
-    an existing contact and can be updated as needed. 
+    !!! note
+        If contact information such as phone number or email address
+        are included in the grid profile, those values will be populated for
+        an existing contact and can be updated as needed. 
 
 -   **Open Pledges:** Click on the down arrow to see all open pledges
     for the contact. You can assign the payment to any of the

--- a/docs/sms-text-messaging/set-up.md
+++ b/docs/sms-text-messaging/set-up.md
@@ -198,12 +198,16 @@ Settings**> **SMS Providers**. Click **Add New Provider**.
     * API URL: leave as "https://api.twilio.com/"
     * API Parameters: enter "From=" followed by your Twilio phone number from the
     previous step, in international format with no spaces. On a second line, enter "mo=1".
-    * NOTE: Twilio will only allow you to send around 200 messages per day from each long
-    number. If you want to send more messages per day and you cannot afford a short code,
-    you can get additional long numbers from Twilio. Include those additional numbers by 
-    listing them, separated by a `|` (the "pipe" character). For example: 
-    `From=12345051212|19875052323|15675052345`. When you incude multiple long numbers, one
-    number is chosen at random each time an SMS message is sent.
+    
+    !!! note
+        Twilio will only allow you to send around 200 messages per day from 
+        each long number. If you want to send more messages per day and you 
+        cannot afford a short code, you can get additional long numbers from 
+        Twilio. Include those additional numbers by listing them, separated by 
+        a `|` (the "pipe" character). For example: 
+        `From=12345051212|19875052323|15675052345`. When you include multiple
+         long numbers, one number is chosen at random each time an SMS message 
+         is sent.
 
 3. Click Save to create your provider.
 

--- a/docs/survey/everyday-tasks.md
+++ b/docs/survey/everyday-tasks.md
@@ -32,13 +32,16 @@ To reserve a group of respondents:
     the contacts to be interviewed.
 4.  You can enter additional criteria to limit your search to a
     geographic area, such as Street Address, Street Name, Street Unit,
-    Street Number, City, Zip/Postal Code. (Note: CiviCRM will parse a
-    street address into Street Name, Street Unit, Street Number - which
-    is extremely useful if you're planning a large door-to-door canvass
-    - only if you turn on address parsing by clicking on **Administer >
-    Administration Console> Configuration Checklist > Address
-    Settings**, then in the **Address Editing** area, check the box for
-    **Street Address Parsing**.)
+    Street Number, City, Zip/Postal Code.
+    
+    !!! note
+        CiviCRM will parse a street address into Street Name, Street Unit, 
+        Street Number - which is extremely useful if you're planning a large 
+        door-to-door canvass - only if you turn on address parsing by clicking 
+        on **Administer > Administration Console> Configuration Checklist > 
+        Address Settings**, then in the **Address Editing** area, check the box 
+        for **Street Address Parsing**.)
+        
 5.  Click **Search.**
 
 *![image](../img/survey_reserve_findrespondents_search.png)*

--- a/docs/the-user-interface/searching.md
+++ b/docs/the-user-interface/searching.md
@@ -56,9 +56,16 @@ CiviCRM also allows for the collection of a nickname when entering new contacts.
 
 You can change this behavior from the *Search Preferences* screen described above by changing the *Include Nickname* setting to *yes*.
 
-Note: If you search by **phone** then you will need to enter the digits of the phone number without any formatting. The **phone** search is done against a field that consists only of digits with all non-numeric characters stripped out.
-
-Note: If you want to search by **first** and **last** name, use the format "Lastname, Firstname", not "Firstname Lastname".  For example, "Peterson, Mary" not "Mary Peterson".
+!!! note
+    If you search by **phone** then you will need to enter the digits of 
+    the phone number without any formatting. The **phone** search is done 
+    against a field that consists only of digits with all non-numeric 
+    characters stripped out.
+    
+!!! tip 
+    If you want to search by **first** and **last** name, use the format 
+    "Lastname, Firstname", not "Firstname Lastname".  
+    For example, "Peterson, Mary" not "Mary Peterson".
 
 ## Advanced search
 ![Screen shot of advanced search](../img/the-user-interface/searching/user-interface-advanced-search-main-screen.png)
@@ -307,12 +314,13 @@ targeted at the most external circles of your constituents.
 
 Search households in a state or province.
 
-Note: which states or provinces are available in the search depends on
-your localization settings. Add additional countries by going to
-**Administer** > **Configure** > **Global Settings** >
-**Localization**. Add to the column of "Available States and Provinces",
-but note this change will also affect profile forms which include
-country or state/province fields.
+!!! note 
+    Which states or provinces are available in the search depends on
+    your localization settings. Add additional countries by going to
+    **Administer** > **Configure** > **Global Settings** >
+    **Localization**. Add to the column of "Available States and Provinces",
+    but note this change will also affect profile forms which include
+    country or state/province fields.
 
 ### **Contribution Aggregate**
 
@@ -336,8 +344,9 @@ geographical area.
 4.  Enter any other parameters you wish to give your search.
 5.  Click **Search**.
 
-**TIP:** You can also incorporate Proximity Searching in a profile which
-you've configured for use as a search form.
+!!! tip
+    You can also incorporate Proximity Searching in a profile which you've 
+    configured for use as a search form.
 
 ### **Event Aggregate**
 


### PR DESCRIPTION
Closes #195 

## Before

In a number of places we had things like

Note: Blah blah blah

![image](https://user-images.githubusercontent.com/6374064/37805482-90b40962-2e32-11e8-8253-2c581f44d2fd.png)

## After

These will be replaced by [admonitions](https://squidfunk.github.io/mkdocs-material/extensions/admonition) where possible.

![image](https://user-images.githubusercontent.com/6374064/37805467-8310d696-2e32-11e8-835c-e4df1137c63b.png)

## Notes

In some cases I didn't think it was really worth making an admonition, and just removed the Note: part. These were cases where I felt a simple sentences was more natural.

After running the grep command suggested in the issue there were still some cases found after my changes. However most of these were sentences containing "Note that..". Removing these with 

`grep -PIr '^(> )?(\*\*)?((Note)|(NOTE)|(Warning)|(WARNING)|(Caution)|(CAUTION)|(Tip)|(TIP)|(Important)|(IMPORTANT)|(NB)|(N\.B\.))' | grep -v "Note that"`

This is what remained:

- `docs/common-workflows/tokens-and-mail-merge.md:Tips`
  A "Tips" section (not a single tip)
- `docs/events/creating-an-event.md:Note, depending on your permissions, you may not be able to edit these`
  Just uses "note" in a sentence
- `docs/civic-engagement/set-up.md:**Tips:**`
  A "Tips" section (not a single tip)
- `docs/survey/set-up.md:**Tips:**`
  A "Tips" section (not a single tip)
- `docs/initial-set-up/security.md:Note: ensure passwords used by one person across several protocols are`
  Could be changed, but this file will be deleted anyway
