### PR TITLE
update to mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ markdown_extensions:
   - pymdownx.betterem
   - pymdownx.mark
 
-nav:
+pages:
 - Home: 'index.md'
 - Introduction:
     - 'What is CiviCRM?': 'introduction/what-is-civicrm.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,15 +8,17 @@ markdown_extensions:
   - attr_list
   - admonition
   - def_list
-  - codehilite(guess_lang=false)
-  - toc(permalink=true)
+  - codehilite:
+      guess_lang: false
+  - toc:
+      permalink: true
   - pymdownx.superfences
   - pymdownx.inlinehilite
   - pymdownx.tilde
   - pymdownx.betterem
   - pymdownx.mark
 
-pages:
+nav:
 - Home: 'index.md'
 - Introduction:
     - 'What is CiviCRM?': 'introduction/what-is-civicrm.md'


### PR DESCRIPTION
The syntax seems to have changed for loading some markdown extensions.  Neither codehilite nor toc would load with the syntax   - codehilite(guess_lang=false)  and   - toc(permalink=true) .  Sytax that does work is 
  - codehilite:
    guess_lang: false
  - toc:
      permalink: true
We also need to change  from using 'pages' to using 'nav' as pages has been deprecated. https://github.com/mkdocs/mkdocs/blob/master/docs/about/release-notes.md#the-pages-configuration-setting-has-been-renamed-to-nav