### PR TITLE
Updating user guide docs to add more info/edits

### DIFF
--- a/docs/appendices/free-software.md
+++ b/docs/appendices/free-software.md
@@ -22,8 +22,8 @@ But the ability to change the software protects you in many ways:
     organisation can hire someone to create it. Of course, the
     organisation can also submit a feature request to the CiviCRM team
     as with any software product.
--   Similarly, anyone can fix a **bug** (error in the software) if he or
-    she has the skills to do so. Because the source code is available,
+-   Similarly, anyone can fix a **bug** (error in the software) if they have
+    the skills to do so. Because the source code is available,
     clients can also find bugs more easily.
 -   Members of the community have much more input into how CiviCRM
     develops than is traditionally available via closed

--- a/docs/appendices/free-software.md
+++ b/docs/appendices/free-software.md
@@ -4,9 +4,9 @@ CiviCRM is **Free Software** - this means it is developed by a community
 and licensed in a generous way so you can use it for free for whatever
 you want.
 
-Free Software (sometimes also referred to as **Free and Open Source
+Free Software (sometimes also referred to as [**Free and Open Source
 Software**, **FLOSS**, **FOSS**, **Software Libre**, or **Open
-Source**) is software that anyone can download, share, and --
+Source**](https://en.wikipedia.org/wiki/Free_and_open-source_software) is software that anyone can download, share, and --
 significantly -- change in any way they want. Practically speaking, you
 might never want to change the software, or even have a staff person who
 can read the **source code** (the instructions written by programmers).

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -38,8 +38,7 @@ register first.
 ## Talking to CiviCRM Consultants
 
 Another option to help you understand CiviCRM is to make use of a
-professional. The CiviCRM website lists [professional vendors and
-consultants](http://civicrm.org/providers) that can walk you through CiviCRM, and
+professional. The CiviCRM website lists [contributors, partners and sponsors](https://civicrm.org/partners-contributors) that can walk you through CiviCRM, and
 there are many others; you may find a local website company who has
 experience with CiviCRM. Consider hiring a consultant for a day to
 discuss with you how CiviCRM could help your organisation.

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -10,6 +10,7 @@ CiviCRM is right for your organisation:
 
 -   identify your organisation's needs
 -   talk to others who use CiviCRM
+-   check out [the CiviCRM Statistics page](https://stats.civicrm.org/?tab=sites)
 -   read [case studies about how similar organizations use CiviCRM](https://civicrm.org/case-studies/)
 -   talk to [a CiviCRM consultant](https://civicrm.org/partners-contributors)
 -   play with [one of many free CiviCRM demonstration sites](https://civicrm.org/demo)

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -40,5 +40,5 @@ register a Stack Exchange account first.
 Another option to help you understand CiviCRM is to make use of a
 professional. The CiviCRM website lists [contributors, partners and sponsors](https://civicrm.org/partners-contributors) that can walk you through CiviCRM, and
 there are many others; you may find a local website company who has
-experience with CiviCRM. Consider hiring a consultant for a day to
+experience with CiviCRM. Consider contacting a consultant for a meeting to
 discuss with you how CiviCRM could help your organisation.

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -15,7 +15,6 @@ CiviCRM is right for your organisation:
 -   play with [one of many free CiviCRM demonstration sites](https://civicrm.org/demo)
 -   download and install [a test CiviCRM database](https://civicrm.org/download) for free
 -   Try [CiviCRM Spark](https://civicrm.org/spark) and easily get your own installation of CiviCRM up-and-running in minutes, starting from $9.50 a month. You can cancel at any time. CiviCRM Spark is ideal for testing and trialing CiviCRM, or for on-going use by smaller organizations and activities with up to 2,000 contacts.
--   read the [Using CiviCRM (2016)](https://www.packtpub.com/web-development/using-civicrm-second-edition) book
 
 ## Talking to others who use CiviCRM
 

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -8,7 +8,6 @@ organisation reach its goals - but it won't be the right choice for
 every organisation. Here are some ways that you can find out whether
 CiviCRM is right for your organisation:
 
--   read the [Using CiviCRM book](https://www.packtpub.com/web-development/using-civicrm-second-edition)! (you might be doing that right now)
 -   identify your organisation needs
 -   talk to others who use CiviCRM
 -   read [case studies about how similar organizations use CiviCRM](https://civicrm.org/case-studies/)
@@ -16,6 +15,7 @@ CiviCRM is right for your organisation:
 -   play with [one of many free CiviCRM demonstration sites](https://civicrm.org/demo)
 -   download and install [a test CiviCRM database](https://civicrm.org/download) for free
 -   Try [CiviCRM Spark](https://civicrm.org/spark) and easily get your own installation of CiviCRM up-and-running in minutes, starting from $9.50 a month. You can cancel at any time. CiviCRM Spark is ideal for testing and trialing CiviCRM, or for on-going use by smaller organizations and activities with up to 2,000 contacts.
+-   read the [Using CiviCRM book](https://www.packtpub.com/web-development/using-civicrm-second-edition)! (you might be doing that right now)
 
 ## Talking to others who use CiviCRM
 

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -37,8 +37,8 @@ register a Stack Exchange account first.
 
 ## Talking to CiviCRM Consultants
 
-Another option to help you understand CiviCRM is to make use of a
+Another option to help you understand CiviCRM is to talk with a
 professional. The CiviCRM website lists [contributors, partners and sponsors](https://civicrm.org/partners-contributors) that can walk you through CiviCRM, and
 there are many others; you may find a local website company who has
 experience with CiviCRM. Consider contacting a consultant for a meeting to
-discuss with you how CiviCRM could help your organisation.
+discuss how CiviCRM could help your organisation.

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -33,7 +33,7 @@ model). This can improve the service you receive from the forums
 considerably! 
 Stack Exchange questions are answered by volunteers, so the easier it is for them to understand, the more quickly the answers will come.
 If you wish to ask questions or contribute to the discussions you must 
-register first.
+register a Stack Exchange account first.
 
 ## Talking to CiviCRM Consultants
 

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -12,7 +12,7 @@ CiviCRM is right for your organisation:
 -   identify your organisation needs
 -   talk to others who use CiviCRM
 -   read [case studies about how similar organizations use CiviCRM](https://civicrm.org/case-studies/)
--   talk to a CiviCRM consultant
+-   talk to [a CiviCRM consultant](https://civicrm.org/partners-contributors)
 -   play with [one of many free CiviCRM demonstration sites](https://civicrm.org/demo)
 -   download and install [a test CiviCRM database ](https://civicrm.org/download) for free
 -   Try [CiviCRM Spark](https://civicrm.org/spark) and easily get your own installation of CiviCRM up-and-running in minutes, starting from $9.50 a month. CiviCRM Spark is ideal for testing and trialing CiviCRM, or for on-going use by smaller organizations and activities with up to 2,000 contacts.

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -14,8 +14,8 @@ CiviCRM is right for your organisation:
 -   read [case studies about how similar organizations use CiviCRM](https://civicrm.org/case-studies/)
 -   talk to [a CiviCRM consultant](https://civicrm.org/partners-contributors)
 -   play with [one of many free CiviCRM demonstration sites](https://civicrm.org/demo)
--   download and install [a test CiviCRM database ](https://civicrm.org/download) for free
--   Try [CiviCRM Spark](https://civicrm.org/spark) and easily get your own installation of CiviCRM up-and-running in minutes, starting from $9.50 a month. CiviCRM Spark is ideal for testing and trialing CiviCRM, or for on-going use by smaller organizations and activities with up to 2,000 contacts.
+-   download and install [a test CiviCRM database](https://civicrm.org/download) for free
+-   Try [CiviCRM Spark](https://civicrm.org/spark) and easily get your own installation of CiviCRM up-and-running in minutes, starting from $9.50 a month. You can cancel your CiviCRM Spark hosting at any time. CiviCRM Spark is ideal for testing and trialing CiviCRM, or for on-going use by smaller organizations and activities with up to 2,000 contacts.
 
 ## Talking to others who use CiviCRM
 

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -8,7 +8,7 @@ organisation reach its goals - but it won't be the right choice for
 every organisation. Here are some ways that you can find out whether
 CiviCRM is right for your organisation:
 
--   read the book! (you might be doing that right now)
+-   read the [Using CiviCRM book](https://www.packtpub.com/web-development/using-civicrm-second-edition)! (you might be doing that right now)
 -   identify your organisation needs
 -   talk to others who use CiviCRM
 -   read [case studies about how similar organizations use CiviCRM](https://civicrm.org/case-studies/)

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -15,7 +15,7 @@ CiviCRM is right for your organisation:
 -   play with [one of many free CiviCRM demonstration sites](https://civicrm.org/demo)
 -   download and install [a test CiviCRM database](https://civicrm.org/download) for free
 -   Try [CiviCRM Spark](https://civicrm.org/spark) and easily get your own installation of CiviCRM up-and-running in minutes, starting from $9.50 a month. You can cancel at any time. CiviCRM Spark is ideal for testing and trialing CiviCRM, or for on-going use by smaller organizations and activities with up to 2,000 contacts.
--   read the [Using CiviCRM book](https://www.packtpub.com/web-development/using-civicrm-second-edition)! (you might be doing that right now)
+-   read the [Using CiviCRM (2016)](https://www.packtpub.com/web-development/using-civicrm-second-edition) book
 
 ## Talking to others who use CiviCRM
 

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -8,7 +8,7 @@ organisation reach its goals - but it won't be the right choice for
 every organisation. Here are some ways that you can find out whether
 CiviCRM is right for your organisation:
 
--   identify your organisation needs
+-   identify your organisation's needs
 -   talk to others who use CiviCRM
 -   read [case studies about how similar organizations use CiviCRM](https://civicrm.org/case-studies/)
 -   talk to [a CiviCRM consultant](https://civicrm.org/partners-contributors)

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -15,7 +15,7 @@ CiviCRM is right for your organisation:
 -   talk to [a CiviCRM consultant](https://civicrm.org/partners-contributors)
 -   play with [one of many free CiviCRM demonstration sites](https://civicrm.org/demo)
 -   download and install [a test CiviCRM database](https://civicrm.org/download) for free
--   Try [CiviCRM Spark](https://civicrm.org/spark) and easily get your own installation of CiviCRM up-and-running in minutes, starting from $9.50 a month. You can cancel your CiviCRM Spark hosting at any time. CiviCRM Spark is ideal for testing and trialing CiviCRM, or for on-going use by smaller organizations and activities with up to 2,000 contacts.
+-   Try [CiviCRM Spark](https://civicrm.org/spark) and easily get your own installation of CiviCRM up-and-running in minutes, starting from $9.50 a month. You can cancel at any time. CiviCRM Spark is ideal for testing and trialing CiviCRM, or for on-going use by smaller organizations and activities with up to 2,000 contacts.
 
 ## Talking to others who use CiviCRM
 

--- a/docs/introduction/is-civicrm-for-you.md
+++ b/docs/introduction/is-civicrm-for-you.md
@@ -9,13 +9,13 @@ every organisation. Here are some ways that you can find out whether
 CiviCRM is right for your organisation:
 
 -   identify your organisation's needs
--   talk to others who use CiviCRM
 -   check out [the CiviCRM Statistics page](https://stats.civicrm.org/?tab=sites)
 -   read [case studies about how similar organizations use CiviCRM](https://civicrm.org/case-studies/)
--   talk to [a CiviCRM consultant](https://civicrm.org/partners-contributors)
 -   play with [one of many free CiviCRM demonstration sites](https://civicrm.org/demo)
+-   talk to others who use CiviCRM
+-   talk to [a CiviCRM consultant](https://civicrm.org/partners-contributors)
+-   Try [CiviCRM Spark](https://civicrm.org/spark) and easily get your own installation of CiviCRM up-and-running in minutes on SAS hosting, starting from $9.50 a month. You can cancel at any time. CiviCRM Spark is ideal for testing and trialing CiviCRM, or for on-going use by smaller organizations and activities with up to 2,000 contacts.
 -   download and install [a test CiviCRM database](https://civicrm.org/download) for free
--   Try [CiviCRM Spark](https://civicrm.org/spark) and easily get your own installation of CiviCRM up-and-running in minutes, starting from $9.50 a month. You can cancel at any time. CiviCRM Spark is ideal for testing and trialing CiviCRM, or for on-going use by smaller organizations and activities with up to 2,000 contacts.
 
 ## Talking to others who use CiviCRM
 

--- a/docs/introduction/real-world-examples.md
+++ b/docs/introduction/real-world-examples.md
@@ -6,6 +6,8 @@ might have several hundred. Their needs range from very simple to fairly
 complex. In this chapter, we will have a look at real world examples of
 how organizations are using CiviCRM.
 
+In addition to the detailed real world examples below, many [case studies are available on CiviCRM.org](https://civicrm.org/case-studies/), and may help you explore more real world uses of CiviCRM. The [CiviCRM Statistics](https://stats.civicrm.org/?tab=sites) site can also give you an overview of real world usage.
+
 Throughout this chapter you will see references to CiviCRM features such
 as CiviEmail, CiviMember, CiviPledge, CiviCRM Profiles and others. These
 are all components of CiviCRM and we have included references to them so

--- a/docs/introduction/real-world-examples.md
+++ b/docs/introduction/real-world-examples.md
@@ -6,7 +6,7 @@ might have several hundred. Their needs range from very simple to fairly
 complex. In this chapter, we will have a look at real world examples of
 how organizations are using CiviCRM.
 
-In addition to the detailed examples below, many [case studies are available on CiviCRM.org](https://civicrm.org/case-studies/), and may help you explore more uses of CiviCRM. The [CiviCRM Statistics](https://stats.civicrm.org/?tab=sites) site can also give you an overview of current usage.
+In addition to the detailed examples below, many [case studies are available on CiviCRM.org](https://civicrm.org/case-studies/), and will help you explore more uses of CiviCRM. The [CiviCRM Statistics](https://stats.civicrm.org/?tab=sites) site can also give you an overview of current usage.
 
 Throughout this chapter you will see references to CiviCRM features such
 as CiviEmail, CiviMember, CiviPledge, CiviCRM Profiles and others. These

--- a/docs/introduction/real-world-examples.md
+++ b/docs/introduction/real-world-examples.md
@@ -6,7 +6,7 @@ might have several hundred. Their needs range from very simple to fairly
 complex. In this chapter, we will have a look at real world examples of
 how organizations are using CiviCRM.
 
-In addition to the detailed real world examples below, many [case studies are available on CiviCRM.org](https://civicrm.org/case-studies/), and may help you explore more real world uses of CiviCRM. The [CiviCRM Statistics](https://stats.civicrm.org/?tab=sites) site can also give you an overview of real world usage.
+In addition to the detailed examples below, many [case studies are available on CiviCRM.org](https://civicrm.org/case-studies/), and may help you explore more uses of CiviCRM. The [CiviCRM Statistics](https://stats.civicrm.org/?tab=sites) site can also give you an overview of current usage.
 
 Throughout this chapter you will see references to CiviCRM features such
 as CiviEmail, CiviMember, CiviPledge, CiviCRM Profiles and others. These

--- a/docs/introduction/what-is-civicrm.md
+++ b/docs/introduction/what-is-civicrm.md
@@ -1,8 +1,11 @@
 # What is CiviCRM?
 
 CiviCRM is a powerful, web-based constituent relationship management (CRM)
-system built by and for nonprofit organizations and NGO's. It allows organisations to record 
-and manage information about the various people and organizations they interacts with. CiviCRM is more
+system built by and for nonprofit organizations and NGO's. As of 2019, over 
+[11,000 non-profits use CiviCRM](https://stats.civicrm.org/?tab=sites). Together, they've managed over 300,000,000 
+contacts, 265,000,000 donations, and handled over 42,000,000 event registrations. 
+CiviCRM allows organisations to record and manage all this information about the 
+various people and organizations they interact with. CiviCRM is more
 than just an address book, it is a flexible platform that allows users to manage a range of interactions 
 including donations, events, memberships, activities, cases, campaigns, mailings and more, all located 
 in a single system that integrates tightly with popular open source content management systems (CMS).

--- a/docs/introduction/what-is-civicrm.md
+++ b/docs/introduction/what-is-civicrm.md
@@ -2,8 +2,8 @@
 
 CiviCRM is a powerful, web-based constituent relationship management (CRM)
 system built by and for nonprofit organizations and NGO's. As of 2019, over 
-[11,000 non-profits use CiviCRM](https://stats.civicrm.org/?tab=sites). CiviCRM has managed over 300,000,000 
-contacts, 265,000,000 donations, and handled over 42,000,000 event registrations. 
+[11,000 non-profits use CiviCRM](https://stats.civicrm.org/?tab=sites). CiviCRM manags over 303,000,000 
+contacts, more than 265,000,000 donations, and handled over 42,000,000 event registrations. 
 CiviCRM allows organisations to record and manage all this information about the 
 various people and organizations they interact with. CiviCRM is more
 than just an address book, it is a flexible platform that allows users to manage a range of interactions 

--- a/docs/introduction/what-is-civicrm.md
+++ b/docs/introduction/what-is-civicrm.md
@@ -2,7 +2,7 @@
 
 CiviCRM is a powerful, web-based constituent relationship management (CRM)
 system built by and for nonprofit organizations and NGO's. As of 2019, over 
-[11,000 non-profits use CiviCRM](https://stats.civicrm.org/?tab=sites). Together, they've managed over 300,000,000 
+[11,000 non-profits use CiviCRM](https://stats.civicrm.org/?tab=sites). CiviCRM has managed over 300,000,000 
 contacts, 265,000,000 donations, and handled over 42,000,000 event registrations. 
 CiviCRM allows organisations to record and manage all this information about the 
 various people and organizations they interact with. CiviCRM is more

--- a/docs/introduction/what-is-civicrm.md
+++ b/docs/introduction/what-is-civicrm.md
@@ -2,8 +2,8 @@
 
 CiviCRM is a powerful, web-based constituent relationship management (CRM)
 system built by and for nonprofit organizations and NGO's. As of 2019, over 
-[11,000 non-profits use CiviCRM](https://stats.civicrm.org/?tab=sites). CiviCRM manags over 303,000,000 
-contacts, more than 265,000,000 donations, and handled over 42,000,000 event registrations. 
+[11,000 non-profits use CiviCRM](https://stats.civicrm.org/?tab=sites). CiviCRM currently manages over 303,000,000 
+contacts, 265,000,000 donations, and 42,000,000 event registrations. 
 CiviCRM allows organisations to record and manage all this information about the 
 various people and organizations they interact with. CiviCRM is more
 than just an address book, it is a flexible platform that allows users to manage a range of interactions 

--- a/docs/introduction/what-is-civicrm.md
+++ b/docs/introduction/what-is-civicrm.md
@@ -10,7 +10,7 @@ in a single system that integrates tightly with popular open source content mana
 CiviCRM focuses on the needs of non-profits, NGO's and civic sector organizations, empowering communications, community engagement, activism,
 outreach, donor management, and much more.
 
-CiviCRM is **Free/Open Source** software, which means there are no
+CiviCRM is [**Free/Open Source** software](https://en.wikipedia.org/wiki/Free_and_open-source_software), which means there are no
 license costs or user fees associated with downloading, installing, or
 using the software. Being Free/Open Source also ensures that you have
 the freedom to view and modify the source code and to distribute copies

--- a/docs/the-civicrm-community/the-civicrm-community.md
+++ b/docs/the-civicrm-community/the-civicrm-community.md
@@ -29,8 +29,6 @@ The [CiviCRM Stack Exchange](http://civicrm.stackexchange.com/) site is specific
 
 [Mattermost](https://chat.civicrm.org) offers live discussion in chat rooms and direct messages. It's a great place to go for any technical questions. Here, with a bit of luck, you'll often find an instant answer to your question or a pointer in the right direction.
 
-The [CiviCRM Forums](http://forum.civicrm.org) are a location for language and locality based CiviCRM discussion and support.
-
 You'll hopefully find that both Stack Exchange and Mattermost are great
 sources for help, support, and good ideas. That's all attributable to
 the good will and generous efforts of people like you! Everyone who

--- a/docs/the-civicrm-community/the-civicrm-community.md
+++ b/docs/the-civicrm-community/the-civicrm-community.md
@@ -57,8 +57,8 @@ channels. Using your favorite engine to search for CiviCRM will turn up
 many articles and posts from other folks' websites and blogs. The
 CiviCRM team is good at keeping an eye out for these posts and often
 publicize them through Twitter. To keep abreast of the stream of
-comments, follow @civicrm and find CiviCRM tweets and tag your own
-tweets with the #civicrm hashtag.
+comments, follow [@civicrm](https://twitter.com/civicrm) and find CiviCRM tweets and tag your own
+tweets with the [#civicrm hashtag](https://twitter.com/hashtag/CiviCRM?src=hash).
 
 ## Finding the Community Offline
 


### PR DESCRIPTION
More fleshing out of the user guide, with particular emphasis on adding links to CiviCRM.org resources, such as the Case Studies, Statistics page, and other things aimed at smoothing the process of learning about CiviCRM. Additionally, when discovered, removing references to no-longer-existing resources like the forums, book.civicrm.org, etc.