### PR TITLE
Formatting fix for note tag

### DIFF
--- a/docs/the-user-interface/searching-url-support.md
+++ b/docs/the-user-interface/searching-url-support.md
@@ -5,11 +5,12 @@ In some cases it is possible to bookmark search URLs with parameters in them in 
 The parameters that are accepted by CiviCRM has been changing across versions. However, we have been standardising our approach and the parameters documented here have been added in a 
 standardised manner and can be expected to work going forwards. Testing has been done on 5.20 & 5.21 but some of these parameters are available in earlier versions.
 
-To construct a parameterised url you need to 
-1) ensure the URL contains 'reset=1&force=1' (after the question mark)
-2) add additional supported parameters.
+To construct a parameterised url you need to
 
-!!! note "Date/Time Parameters
+1. ensure the URL contains 'reset=1&force=1' (after the question mark)
+2. add additional supported parameters.
+
+!!! note "Date/Time Parameters"
     Date/time parameters require that, either, the time component is omitted entirely `20200101` or specified with a full **six digit** time `20200101235959`
 
 So, for example, in 5.20 the following URL works on Drupal *(with Clean URL support)* to find contributions made by a person with a name like `Bob`, a contribution source like `dad` made on or before `01 Jan 2018`


### PR DESCRIPTION
Me again. Noticing on the live site the note tag is misformatted. And also the numbered list above it.